### PR TITLE
Use alpine and java 8 for docker images.

### DIFF
--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/driver/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/driver/Dockerfile
@@ -1,12 +1,9 @@
-FROM ubuntu:trusty
+FROM anapsix/alpine-java:8
 
 # Upgrade package index
-# install a few other useful packages plus Open Jdk 7
 # Remove unneeded /var/lib/apt/lists/* after install to reduce the
 # docker image size (by ~30MB)
-RUN apt-get update && \
-    apt-get install -y less openjdk-7-jre-headless net-tools vim-tiny sudo openssh-server procps && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --update vim
 
 RUN mkdir -p /opt/spark
 RUN mkdir -p /opt/spark/ui-resources/org/apache/spark/ui/static
@@ -18,7 +15,6 @@ ADD sbin /opt/spark/sbin
 ADD conf /opt/spark/conf
 
 ENV SPARK_HOME /opt/spark
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
 
 WORKDIR /opt/spark
 

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/driver/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/driver/Dockerfile
@@ -1,10 +1,5 @@
 FROM anapsix/alpine-java:8
 
-# Upgrade package index
-# Remove unneeded /var/lib/apt/lists/* after install to reduce the
-# docker image size (by ~30MB)
-RUN apk add --update vim
-
 RUN mkdir -p /opt/spark
 RUN mkdir -p /opt/spark/ui-resources/org/apache/spark/ui/static
 RUN touch /opt/spark/RELEASE

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/executor/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/executor/Dockerfile
@@ -1,12 +1,9 @@
-FROM ubuntu:trusty
+FROM anapsix/alpine-java:8
 
 # Upgrade package index
-# install a few other useful packages plus Open Jdk 7
 # Remove unneeded /var/lib/apt/lists/* after install to reduce the
 # docker image size (by ~30MB)
-RUN apt-get update && \
-    apt-get install -y less openjdk-7-jre-headless net-tools vim-tiny sudo openssh-server procps && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --update vim
 
 RUN mkdir -p /opt/spark
 RUN mkdir -p /opt/spark/ui-resources/org/apache/spark/ui/static
@@ -18,7 +15,6 @@ ADD sbin /opt/spark/sbin
 ADD conf /opt/spark/conf
 
 ENV SPARK_HOME /opt/spark
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
 
 WORKDIR /opt/spark
 

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/executor/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/executor/Dockerfile
@@ -1,10 +1,5 @@
 FROM anapsix/alpine-java:8
 
-# Upgrade package index
-# Remove unneeded /var/lib/apt/lists/* after install to reduce the
-# docker image size (by ~30MB)
-RUN apk add --update vim
-
 RUN mkdir -p /opt/spark
 RUN mkdir -p /opt/spark/ui-resources/org/apache/spark/ui/static
 RUN touch /opt/spark/RELEASE


### PR DESCRIPTION
The first images were built more closely to what Spark has already done in their Mesos integration tests, but Alpine has a smaller image size and thus is quicker to pull and build with. Also use Java 8 instead of Java 7 as the base.