### PR TITLE
inherit IO to get kubectl logs output

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/KubernetesSparkRestServer.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/KubernetesSparkRestServer.scala
@@ -164,10 +164,7 @@ private[spark] class KubernetesSparkRestServer(
             command += s"-Xmx$driverMemory"
             command += mainClass
             command ++= appArgs
-            val pb = new ProcessBuilder(command: _*)
-            Paths.get(sparkHome, "logs").toFile.mkdirs
-            pb.redirectOutput(Paths.get(sparkHome, "logs", "stdout").toFile)
-            pb.redirectError(Paths.get(sparkHome, "logs", "stderr").toFile)
+            val pb = new ProcessBuilder(command: _*).inheritIO()
             val process = pb.start()
             ShutdownHookManager.addShutdownHook(() => {
               logInfo("Received stop command, shutting down the running Spark application...")


### PR DESCRIPTION
@ash211 @mccheah I was thinking about the logging that we have, where we redirect output to files. 

* There are no imposed file size limits
* Fetching it for inspection isn't currently very easy. 

Using the container's stdout/stderr instead of redirecting to file the way we do it currently may be advantageous, because it has the logic to rotate logs, and keep 5 of the most recent ones (each 10M in size). This also allows for the use of `kubectl logs` directly, which would be analogous to `yarn logs`.