### PR TITLE
Add kubernetes profile to travis CI yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ notifications:
 # 5. Run maven install before running lint-java.
 install:
   - export MAVEN_SKIP_RC=1
-  - build/mvn -T 4 -q -DskipTests -Pmesos -Pyarn -Phadoop-2.3 -Pkinesis-asl -Phive -Phive-thriftserver install
+  - build/mvn -T 4 -q -DskipTests -Pmesos -Pyarn -Phadoop-2.3 -Pkubernetes -Pkinesis-asl -Phive -Phive-thriftserver install
 
 # 6. Run lint-java.
 script:

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/CompressionUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/CompressionUtils.scala
@@ -38,11 +38,11 @@ private[spark] object CompressionUtils extends Logging {
 
   /**
    * Compresses all of the given paths into a gzipped-tar archive, returning the compressed data in
-   * memory as an instance of {@link TarGzippedData}. The files are taken without consideration to their
-   * original folder structure, and are added to the tar archive in a flat hierarchy. Directories are
-   * not allowed, and duplicate file names are de-duplicated by appending a numeric suffix to the file name,
-   * before the file extension. For example, if paths a/b.txt and b/b.txt were provided, then the files added
-   * to the tar archive would be b.txt and b-1.txt.
+   * memory as an instance of {@link TarGzippedData}. The files are taken without consideration to
+   * their original folder structure, and are added to the tar archive in a flat hierarchy.
+   * Directories are not allowed, and duplicate file names are de-duplicated by appending a numeric
+   * suffix to the file name, before the file extension. For example, if paths a/b.txt and b/b.txt
+   * were provided, then the files added to the tar archive would be b.txt and b-1.txt.
    * @param paths A list of file paths to be archived
    * @return An in-memory representation of the compressed data.
    */


### PR DESCRIPTION
@ssuchter @foxish @ash211 

The current .[travis.yml](https://github.com/apache-spark-on-k8s/spark/blob/k8s-support-alternate-incremental/.travis.yml) file does not use the kubernetes build profile. This change adds the profile so the CI builds will compile kubernetes code.

Note this may make Travis unhappy again. If fixes are trivial, I can include them in this pull request too.