### PR TITLE
A number of small tweaks to the MVP.

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -42,11 +42,10 @@ are set up as described above:
       --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest
       examples/jars/spark_2.11-2.2.0.jar
 
-<!-- TODO master should default to https if no scheme is specified -->
 The Spark master, specified either via passing the `--master` command line argument to `spark-submit` or by setting
 `spark.master` in the application's configuration, must be a URL with the format `k8s://<api_server_url>`. Prefixing the
 master string with `k8s://` will cause the Spark application to launch on the Kubernetes cluster, with the API server
-being contacted at `api_server_url`. The HTTP protocol must also be specified.
+being contacted at `api_server_url`. If no HTTP protocol is specified in the URL, it defaults to `https`.
 
 Note that applications can currently only be executed in cluster mode, where the driver and its executors are running on
 the cluster.
@@ -58,17 +57,18 @@ disk of the submitter's machine. These two types of dependencies are specified v
 `spark-submit`:
  
 * Local jars provided by specifying the `--jars` command line argument to `spark-submit`, or by setting `spark.jars` in
-  the application's configuration, will be treated as jars that are located on the *disk of the driver Docker
-  container*. This only applies to jar paths that do not specify a scheme or that have the scheme `file://`. Paths with
-  other schemes are fetched from their appropriate locations.
+  the application's configuration, will be treated as jars that are located on the *disk of the driver container*. This
+  only applies to jar paths that do not specify a scheme or that have the scheme `file://`. Paths with other schemes are
+  fetched from their appropriate locations.
 * Local jars provided by specifying the `--upload-jars` command line argument to `spark-submit`, or by setting
   `spark.kubernetes.driver.uploads.jars` in the application's configuration, will be treated as jars that are located on
   the *disk of the submitting machine*. These jars are uploaded to the driver docker container before executing the
   application.
-  <!-- TODO support main resource bundled in the Docker image -->
 * A main application resource path that does not have a scheme or that has the scheme `file://` is assumed to be on the
   *disk of the submitting machine*. This resource is uploaded to the driver docker container before executing the
   application. A remote path can still be specified and the resource will be fetched from the appropriate location.
+* A main application resource path that has the scheme `container://` is assumed to be on the *disk of the driver
+  container*.
   
 In all of these cases, the jars are placed on the driver's classpath, and are also sent to the executors. Below are some
 examples of providing application dependencies.
@@ -78,8 +78,7 @@ To submit an application with both the main resource and two other jars living o
     bin/spark-submit
       --deploy-mode cluster
       --class com.example.applications.SampleApplication
-      --master k8s://https://192.168.99.100
-      --kubernetes-namespace default 
+      --master k8s://192.168.99.100:8443
       --upload-jars /home/exampleuser/exampleapplication/dep1.jar,/home/exampleuser/exampleapplication/dep2.jar
       --conf spark.kubernetes.driver.docker.image=registry-host:5000/spark-driver:latest
       --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest
@@ -91,8 +90,7 @@ Note that since passing the jars through the `--upload-jars` command line argume
     bin/spark-submit
       --deploy-mode cluster
       --class com.example.applications.SampleApplication
-      --master k8s://https://192.168.99.100
-      --kubernetes-namespace default 
+      --master k8s://192.168.99.100:8443
       --conf spark.kubernetes.driver.uploads.jars=/home/exampleuser/exampleapplication/dep1.jar,/home/exampleuser/exampleapplication/dep2.jar
       --conf spark.kubernetes.driver.docker.image=registry-host:5000/spark-driver:latest
       --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest
@@ -104,8 +102,7 @@ is located in the jar `/opt/spark-plugins/app-plugin.jar` on the docker image's 
     bin/spark-submit 
       --deploy-mode cluster 
       --class com.example.applications.PluggableApplication
-      --master k8s://https://192.168.99.100
-      --kubernetes-namespace default 
+      --master k8s://192.168.99.100:8443
       --jars /opt/spark-plugins/app-plugin.jar
       --conf spark.kubernetes.driver.docker.image=registry-host:5000/spark-driver-custom:latest
       --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest
@@ -117,13 +114,22 @@ Spark property, the above will behave identically to this command:
     bin/spark-submit 
       --deploy-mode cluster 
       --class com.example.applications.PluggableApplication
-      --master k8s://https://192.168.99.100
-      --kubernetes-namespace default 
+      --master k8s://192.168.99.100:8443
       --conf spark.jars=file:///opt/spark-plugins/app-plugin.jar
       --conf spark.kubernetes.driver.docker.image=registry-host:5000/spark-driver-custom:latest
       --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest
       http://example.com:8080/applications/sparkpluggable/app.jar
       
+To specify a main application resource that is in the Docker image, and if it has no other dependencies:
+
+    bin/spark-submit
+      --deploy-mode cluster
+      --class com.example.applications.PluggableApplication
+      --master k8s://192.168.99.100:8443
+      --conf spark.kubernetes.driver.docker.image=registry-host:5000/spark-driver-custom:latest
+      --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest
+      container:///home/applications/examples/example.jar
+
 ### Spark Properties
 
 Below are some other common properties that are specific to Kubernetes. Most of the other configurations are the same
@@ -133,10 +139,9 @@ from the other deployment modes. See the [configuration page](configuration.html
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td><code>spark.kubernetes.namespace</code></td>
-  <!-- TODO set default to "default" -->
-  <td>(none)</td>
+  <td><code>default</code></td>
   <td>
-    The namespace that will be used for running the driver and executor pods. Must be specified. When using
+    The namespace that will be used for running the driver and executor pods. When using
     <code>spark-submit</code> in cluster mode, this can also be passed to <code>spark-submit</code> via the
     <code>--kubernetes-namespace</code> command line argument.
   </td>
@@ -194,14 +199,6 @@ from the other deployment modes. See the [configuration page](configuration.html
   <td>
     Comma-separated list of jars to sent to the driver and all executors when submitting the application in cluster
     mode. Refer to <a href="running-on-kubernetes.html#adding-other-jars">adding other jars</a> for more information.
-  </td>
-</tr>
-<tr>
-  <!-- TODO remove this functionality -->
-  <td><code>spark.kubernetes.driver.uploads.driverExtraClasspath</code></td>
-  <td>(none)</td>
-  <td>
-    Comma-separated list of jars to be sent to the driver only when submitting the application in cluster mode. 
   </td>
 </tr>
 <tr>

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -45,7 +45,9 @@ are set up as described above:
 The Spark master, specified either via passing the `--master` command line argument to `spark-submit` or by setting
 `spark.master` in the application's configuration, must be a URL with the format `k8s://<api_server_url>`. Prefixing the
 master string with `k8s://` will cause the Spark application to launch on the Kubernetes cluster, with the API server
-being contacted at `api_server_url`. If no HTTP protocol is specified in the URL, it defaults to `https`.
+being contacted at `api_server_url`. If no HTTP protocol is specified in the URL, it defaults to `https`. For example,
+setting the master to `k8s://example.com:443` is equivalent to setting it to `k8s://https://example.com:443`, but to
+connect without SSL on a different port, the master would be set to `k8s://http://example.com:8443`.
 
 Note that applications can currently only be executed in cluster mode, where the driver and its executors are running on
 the cluster.

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/KubernetesRestProtocolMessages.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/KubernetesRestProtocolMessages.scala
@@ -27,7 +27,6 @@ case class KubernetesCreateSubmissionRequest(
   val appArgs: Array[String],
   val sparkProperties: Map[String, String],
   val secret: String,
-  val uploadedDriverExtraClasspathBase64Contents: Option[TarGzippedData],
   val uploadedJarsBase64Contents: Option[TarGzippedData]) extends SubmitRestProtocolRequest {
   message = "create"
   clientSparkVersion = SPARK_VERSION
@@ -46,12 +45,15 @@ case class TarGzippedData(
   property = "type")
 @JsonSubTypes(value = Array(
   new JsonSubTypes.Type(value = classOf[UploadedAppResource], name = "UploadedAppResource"),
+  new JsonSubTypes.Type(value = classOf[ContainerAppResource], name = "ContainerLocalAppResource"),
   new JsonSubTypes.Type(value = classOf[RemoteAppResource], name = "RemoteAppResource")))
 abstract class AppResource
 
 case class UploadedAppResource(
   resourceBase64Contents: String,
   name: String = "spark-app-resource") extends AppResource
+
+case class ContainerAppResource(resourcePath: String) extends AppResource
 
 case class RemoteAppResource(resource: String) extends AppResource
 

--- a/resource-managers/kubernetes/docker-minimal-bundle/pom.xml
+++ b/resource-managers/kubernetes/docker-minimal-bundle/pom.xml
@@ -43,6 +43,13 @@
       <version>${project.version}</version>
       <type>pom</type>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-examples_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <!--
       Because we don't shade dependencies anymore, we need to restore Guava to compile scope so
       that the libraries Spark depend on have it available. We'll package the version that Spark

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/driver-assembly.xml
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/driver-assembly.xml
@@ -24,15 +24,6 @@
   <fileSets>
     <fileSet>
       <directory>
-        ${project.parent.basedir}/core/src/main/resources/org/apache/spark/ui/static/
-      </directory>
-      <outputDirectory>ui-resources/org/apache/spark/ui/static</outputDirectory>
-      <includes>
-        <include>**/*</include>
-      </includes>
-    </fileSet>
-    <fileSet>
-      <directory>
         ${project.parent.basedir}/sbin/
       </directory>
       <outputDirectory>sbin</outputDirectory>
@@ -78,7 +69,18 @@
       <excludes>
         <exclude>org.apache.spark:spark-assembly_${scala.binary.version}:pom</exclude>
         <exclude>org.spark-project.spark:unused</exclude>
+        <exclude>org.apache.spark:spark-examples_${scala.binary.version}</exclude>
       </excludes>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory>examples/jars</outputDirectory>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
+      <unpack>false</unpack>
+      <scope>provided</scope>
+      <useProjectArtifact>false</useProjectArtifact>
+      <includes>
+        <include>org.apache.spark:spark-examples_${scala.binary.version}:jar</include>
+      </includes>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/executor-assembly.xml
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/executor-assembly.xml
@@ -78,7 +78,18 @@
       <excludes>
         <exclude>org.apache.spark:spark-assembly_${scala.binary.version}:pom</exclude>
         <exclude>org.spark-project.spark:unused</exclude>
+        <exclude>org.apache.spark:spark-examples_${scala.binary.version}</exclude>
       </excludes>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory>examples/jars</outputDirectory>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
+      <unpack>false</unpack>
+      <scope>provided</scope>
+      <useProjectArtifact>false</useProjectArtifact>
+      <includes>
+        <include>org.apache.spark:spark-examples_${scala.binary.version}:jar</include>
+      </includes>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/driver/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/driver/Dockerfile
@@ -8,6 +8,7 @@ RUN mkdir -p /opt/spark
 RUN touch /opt/spark/RELEASE
 
 ADD jars /opt/spark/jars
+ADD examples /opt/spark/examples
 ADD bin /opt/spark/bin
 ADD sbin /opt/spark/sbin
 ADD conf /opt/spark/conf

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/executor/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/executor/Dockerfile
@@ -8,6 +8,7 @@ RUN mkdir -p /opt/spark
 RUN touch /opt/spark/RELEASE
 
 ADD jars /opt/spark/jars
+ADD examples /opt/spark/examples
 ADD bin /opt/spark/bin
 ADD sbin /opt/spark/sbin
 ADD conf /opt/spark/conf

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
@@ -18,21 +18,26 @@ package org.apache.spark.deploy.kubernetes.integrationtest
 
 import java.nio.file.Paths
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 import com.google.common.collect.ImmutableList
-import io.fabric8.kubernetes.client.{Config, KubernetesClient}
+import com.google.common.util.concurrent.SettableFuture
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.{Config, KubernetesClient, KubernetesClientException, Watcher}
+import io.fabric8.kubernetes.client.Watcher.Action
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.{Eventually, PatienceConfiguration}
 import org.scalatest.time.{Minutes, Seconds, Span}
 import scala.collection.JavaConverters._
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.deploy.SparkSubmit
 import org.apache.spark.deploy.kubernetes.Client
 import org.apache.spark.deploy.kubernetes.integrationtest.docker.SparkDockerImageBuilder
 import org.apache.spark.deploy.kubernetes.integrationtest.minikube.Minikube
 import org.apache.spark.deploy.kubernetes.integrationtest.restapis.SparkRestApiV1
 import org.apache.spark.status.api.v1.{ApplicationStatus, StageStatus}
+import org.apache.spark.util.Utils
 
 private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
 
@@ -45,6 +50,15 @@ private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
       .toFile
       .listFiles()(0)
       .getAbsolutePath
+
+  private val EXAMPLES_JAR_FILE_NAME = Paths.get("target", "docker", "driver", "examples", "jars")
+    .toFile
+    .listFiles()
+    .toList
+    .map(_.getName)
+    .find(_.startsWith("spark-examples"))
+    .getOrElse(throw new IllegalStateException("Expected to find spark-examples jar; was the" +
+        " pre-integration-test phase run?"))
 
   private val TIMEOUT = PatienceConfiguration.Timeout(Span(2, Minutes))
   private val INTERVAL = PatienceConfiguration.Interval(Span(2, Seconds))
@@ -160,5 +174,60 @@ private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
     val sparkMetricsService = Minikube.getService[SparkRestApiV1](
       "spark-pi", NAMESPACE, "spark-ui-port")
     expectationsForStaticAllocation(sparkMetricsService)
+  }
+
+  test("Run using spark-submit with the examples jar on the docker image") {
+    val args = Array(
+      "--master", s"k8s://${Minikube.getMinikubeIp}:8443",
+      "--deploy-mode", "cluster",
+      "--kubernetes-namespace", NAMESPACE,
+      "--name", "spark-pi",
+      "--executor-memory", "512m",
+      "--executor-cores", "1",
+      "--num-executors", "1",
+      "--upload-jars", HELPER_JAR,
+      "--class", "org.apache.spark.examples.SparkPi",
+      "--conf", s"spark.kubernetes.submit.caCertFile=${clientConfig.getCaCertFile}",
+      "--conf", s"spark.kubernetes.submit.clientKeyFile=${clientConfig.getClientKeyFile}",
+      "--conf", s"spark.kubernetes.submit.clientCertFile=${clientConfig.getClientCertFile}",
+      "--conf", "spark.kubernetes.executor.docker.image=spark-executor:latest",
+      "--conf", "spark.kubernetes.driver.docker.image=spark-driver:latest",
+      s"container:///opt/spark/examples/jars/$EXAMPLES_JAR_FILE_NAME")
+    val allContainersSucceeded = SettableFuture.create[Boolean]
+    val watcher = new Watcher[Pod] {
+      override def eventReceived(action: Action, pod: Pod): Unit = {
+        if (action == Action.ERROR) {
+          allContainersSucceeded.setException(
+              new SparkException("The execution of the driver pod failed."))
+        } else if (action == Action.MODIFIED &&
+            pod.getStatus.getContainerStatuses.asScala.nonEmpty &&
+            pod.getStatus
+              .getContainerStatuses
+              .asScala
+              .forall(_.getState.getTerminated != null)) {
+          allContainersSucceeded.set(
+            pod.getStatus
+              .getContainerStatuses
+              .asScala
+              .forall(_.getState.getTerminated.getExitCode == 0)
+          )
+        }
+      }
+
+      override def onClose(e: KubernetesClientException): Unit = {
+        logError("Integration test pod watch closed", e)
+      }
+    }
+    Utils.tryWithResource(
+      minikubeKubernetesClient
+        .pods
+        .withName("spark-pi")
+        .watch(watcher)) { unused =>
+      SparkSubmit.main(args)
+      assert(allContainersSucceeded.get(2, TimeUnit.MINUTES),
+          "Some containers exited with a non-zero status.")
+    }
+    val jobLog = minikubeKubernetesClient.pods.withName("spark-pi").getLog
+    assert(jobLog.contains("Pi is roughly"), "Pi was not computed by the job...")
   }
 }


### PR DESCRIPTION
- Master protocol defaults to https if not specified
- Removed upload driver extra classpath functionality
- Added ability to specify main app resource with container:// URI
- Shut down the REST server and thus the driver pod once the application completes
- Updated docs to reflect all of the above
- Add examples to Docker images, mostly for integration testing but could be useful for easily getting started without shipping anything to the cluster