### PR TITLE
Access the Driver Launcher Server over NodePort for app launch + submit jars

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -132,6 +132,24 @@ To specify a main application resource that is in the Docker image, and if it ha
       --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest \
       container:///home/applications/examples/example.jar
 
+### Setting Up SSL For Submitting the Driver
+
+When submitting to Kubernetes, a pod is started for the driver, and the pod starts an HTTP server. This HTTP server
+receives the driver's configuration, including uploaded driver jars, from the client before starting the application.
+Spark supports using SSL to encrypt the traffic in this bootstrapping process. It is recommended to configure this
+whenever possible. 
+
+See the [security page](security.html) and [configuration](configuration.html) sections for more information on
+configuring SSL; use the prefix `spark.ssl.kubernetes.driverlaunch` in configuring the SSL-related fields in the context
+of submitting to Kubernetes. For example, to set the trustStore used when the local machine communicates with the driver
+pod in starting the application, set `spark.ssl.kubernetes.driverlaunch.trustStore`.
+
+One note about the keyStore is that it can be specified as either a file on the client machine or a file in the
+container image's disk. Thus `spark.ssl.kubernetes.driverlaunch.keyStore` can be a URI with a scheme of either `file:`
+or `container:`. A scheme of `file:` corresponds to the keyStore being located on the client machine; it is mounted onto
+the driver container as a [secret volume](https://kubernetes.io/docs/user-guide/secrets/). When the URI has the scheme
+`container:`, the file is assumed to already be on the container's disk at the appropriate path.
+
 ### Spark Properties
 
 Below are some other common properties that are specific to Kubernetes. Most of the other configurations are the same

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
     <parquet.version>1.8.1</parquet.version>
     <hive.parquet.version>1.6.0</hive.parquet.version>
     <feign.version>8.18.0</feign.version>
+    <bouncycastle.version>1.52</bouncycastle.version>
     <jetty.version>9.2.16.v20160414</jetty.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <chill.version>0.8.0</chill.version>
@@ -337,7 +338,11 @@
         <artifactId>okhttp</artifactId>
         <version>3.4.1</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
       <!-- This artifact is a shaded version of ASM 5.0.4. The POM that was used to produce this
            is at https://github.com/apache/geronimo-xbean/tree/xbean-4.4/xbean-asm5-shaded
            For context on why we shade ASM, see SPARK-782 and SPARK-6152. -->

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -302,7 +302,7 @@ private[spark] class Client(
     }
     val topLevelMessage = s"The driver pod with name ${driverPod.getMetadata.getName}" +
       s" in namespace ${driverPod.getMetadata.getNamespace} was not ready in" +
-      s" $LAUNCH_TIMEOUT_SECONDS seconds."
+      s" $driverLaunchTimeoutSecs seconds."
     val podStatusPhase = if (driverPod.getStatus.getPhase != null) {
       s"Latest phase from the pod is: ${driverPod.getStatus.getPhase}"
     } else {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -175,12 +175,12 @@ private[spark] class Client(
                             .withName(UI_PORT_NAME)
                             .withPort(uiPort)
                             .withNewTargetPort(uiPort)
-                            .build
+                            .build()
                           kubernetesClient.services().withName(kubernetesAppId).edit()
                             .editSpec()
                               .withType("ClusterIP")
                               .withPorts(uiServicePort)
-                              .endSpec
+                              .endSpec()
                             .done
                         }
                       }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import com.google.common.io.Files
 import com.google.common.util.concurrent.{SettableFuture, ThreadFactoryBuilder}
 import io.fabric8.kubernetes.api.model._
-import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient, KubernetesClient, KubernetesClientException, Watch, Watcher}
+import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient, KubernetesClient, KubernetesClientException, Watcher}
 import io.fabric8.kubernetes.client.Watcher.Action
 import org.apache.commons.codec.binary.Base64
 import scala.collection.JavaConverters._
@@ -105,132 +105,30 @@ private[spark] class Client(
         .withType("Opaque")
         .done()
       try {
-        val resolvedSelectors = (Map(
+        val driverKubernetesSelectors = (Map(
             DRIVER_LAUNCHER_SELECTOR_LABEL -> driverLauncherSelectorValue,
             SPARK_APP_NAME_LABEL -> appName)
           ++ parsedCustomLabels).asJava
-        val containerPorts = configureContainerPorts()
+        val containerPorts = buildContainerPorts()
         val submitCompletedFuture = SettableFuture.create[Boolean]
         val secretDirectory = s"$SPARK_SUBMISSION_SECRET_BASE_DIR/$kubernetesAppId"
         val submitPending = new AtomicBoolean(false)
-        val podWatcher = new Watcher[Pod] {
-          override def eventReceived(action: Action, pod: Pod): Unit = {
-            if ((action == Action.ADDED || action == Action.MODIFIED)
-                && pod.getStatus.getPhase == "Running"
-                && !submitCompletedFuture.isDone) {
-              if (!submitPending.getAndSet(true)) {
-                pod.getStatus
-                  .getContainerStatuses
-                  .asScala
-                  .find(status =>
-                    status.getName == DRIVER_LAUNCHER_CONTAINER_NAME && status.getReady) match {
-                  case Some(_) =>
-                    val driverLauncherServicePort = new ServicePortBuilder()
-                      .withName(DRIVER_LAUNCHER_SERVICE_PORT_NAME)
-                      .withPort(DRIVER_LAUNCHER_SERVICE_INTERNAL_PORT)
-                      .withNewTargetPort(DRIVER_LAUNCHER_SERVICE_INTERNAL_PORT)
-                      .build()
-                    val service = kubernetesClient.services().createNew()
-                      .withNewMetadata()
-                        .withName(kubernetesAppId)
-                        .withLabels(resolvedSelectors)
-                        .endMetadata()
-                      .withNewSpec()
-                        .withType("NodePort")
-                        .withSelector(resolvedSelectors)
-                        .withPorts(driverLauncherServicePort)
-                        .endSpec()
-                      .done()
-                    try {
-                      sparkConf.set("spark.kubernetes.driver.service.name",
-                        service.getMetadata.getName)
-                      sparkConf.setIfMissing("spark.driver.port", DEFAULT_DRIVER_PORT.toString)
-                      sparkConf.setIfMissing("spark.blockmanager.port",
-                        DEFAULT_BLOCKMANAGER_PORT.toString)
-                      val driverLauncher = getDriverLauncherClient(kubernetesClient, service)
-                      val ping = Retry.retry(5, 5.seconds) {
-                        driverLauncher.ping()
-                      }
-                      ping onFailure {
-                        case t: Throwable =>
-                          submitCompletedFuture.setException(t)
-                          kubernetesClient.services().delete(service)
-                      }
-                      val submitComplete = ping.flatMap { _ =>
-                        Future {
-                          sparkConf.set("spark.driver.host", pod.getStatus.getPodIP)
-                          val submitRequest = buildSubmissionRequest()
-                          driverLauncher.create(submitRequest)
-                        }
-                      }
-                      submitComplete onFailure {
-                        case t: Throwable =>
-                          submitCompletedFuture.setException(t)
-                          kubernetesClient.services().delete(service)
-                      }
-                      val adjustServicePort = submitComplete.flatMap { _ =>
-                        Future {
-                          // After submitting, adjust the service to only expose the Spark UI
-                          val uiServicePort = new ServicePortBuilder()
-                            .withName(UI_PORT_NAME)
-                            .withPort(uiPort)
-                            .withNewTargetPort(uiPort)
-                            .build()
-                          kubernetesClient.services().withName(kubernetesAppId).edit()
-                            .editSpec()
-                              .withType("ClusterIP")
-                              .withPorts(uiServicePort)
-                              .endSpec()
-                            .done
-                        }
-                      }
-                      adjustServicePort onSuccess {
-                        case _ =>
-                          submitCompletedFuture.set(true)
-                      }
-                      adjustServicePort onFailure {
-                        case throwable: Throwable =>
-                          submitCompletedFuture.setException(throwable)
-                          kubernetesClient.services().delete(service)
-                      }
-                    } catch {
-                      case e: Throwable =>
-                        submitCompletedFuture.setException(e)
-                        try {
-                          kubernetesClient.services().delete(service)
-                        } catch {
-                          case throwable: Throwable =>
-                            logError("Submitting the job failed but failed to" +
-                              " clean up the created service.", throwable)
-                        }
-                        throw e
-                    }
-                  case None =>
-                }
-              }
-            }
-          }
-
-          override def onClose(e: KubernetesClientException): Unit = {
-            if (!submitCompletedFuture.isDone) {
-              submitCompletedFuture.setException(e)
-            }
-          }
-        }
-
-        def createDriverPod(unused: Watch): Unit = {
+        val podWatcher = new DriverPodWatcher(submitCompletedFuture, submitPending,
+          kubernetesClient, driverKubernetesSelectors)
+        Utils.tryWithResource(kubernetesClient
+            .pods()
+            .withLabels(driverKubernetesSelectors)
+            .watch(podWatcher)) { _ =>
           kubernetesClient.pods().createNew()
             .withNewMetadata()
               .withName(kubernetesAppId)
-              .withLabels(resolvedSelectors)
+              .withLabels(driverKubernetesSelectors)
               .endMetadata()
             .withNewSpec()
               .withRestartPolicy("OnFailure")
               .addNewVolume()
                 .withName(s"spark-submission-secret-volume")
-                  .withNewSecret()
-                  .withSecretName(secret.getMetadata.getName)
-                  .endSecret()
+                .withNewSecret().withSecretName(secret.getMetadata.getName).endSecret()
                 .endVolume
               .withServiceAccount(serviceAccount)
               .addNewContainer()
@@ -260,32 +158,136 @@ private[spark] class Client(
             submitSucceeded = true
           } catch {
             case e: TimeoutException =>
-              val finalErrorMessage: String = getSubmitErrorMessage(kubernetesClient, e)
+              val finalErrorMessage: String = buildSubmitFailedErrorMessage(kubernetesClient, e)
               logError(finalErrorMessage, e)
               throw new SparkException(finalErrorMessage, e)
-            } finally {
-              if (!submitSucceeded) {
-                try {
-                  kubernetesClient.pods.withName(kubernetesAppId).delete
-                } catch {
-                  case throwable: Throwable =>
-                    logError("Failed to delete driver pod after it failed to run.", throwable)
-                }
+          } finally {
+            if (!submitSucceeded) {
+              try {
+                kubernetesClient.pods.withName(kubernetesAppId).delete
+              } catch {
+                case throwable: Throwable =>
+                  logError("Failed to delete driver pod after it failed to run.", throwable)
               }
             }
           }
-
-        Utils.tryWithResource(kubernetesClient
-          .pods()
-          .withLabels(resolvedSelectors)
-          .watch(podWatcher)) { createDriverPod }
+        }
       } finally {
         kubernetesClient.secrets().delete(secret)
       }
     })
   }
 
-  private def getSubmitErrorMessage(
+  private class DriverPodWatcher(
+      submitCompletedFuture: SettableFuture[Boolean],
+      submitPending: AtomicBoolean,
+      kubernetesClient: KubernetesClient,
+      driverKubernetesSelectors: java.util.Map[String, String]) extends Watcher[Pod] {
+    override def eventReceived(action: Action, pod: Pod): Unit = {
+      if ((action == Action.ADDED || action == Action.MODIFIED)
+        && pod.getStatus.getPhase == "Running"
+        && !submitCompletedFuture.isDone) {
+        if (!submitPending.getAndSet(true)) {
+          pod.getStatus
+            .getContainerStatuses
+            .asScala
+            .find(status =>
+              status.getName == DRIVER_LAUNCHER_CONTAINER_NAME && status.getReady) match {
+            case Some(_) =>
+              val driverLauncherServicePort = new ServicePortBuilder()
+                .withName(DRIVER_LAUNCHER_SERVICE_PORT_NAME)
+                .withPort(DRIVER_LAUNCHER_SERVICE_INTERNAL_PORT)
+                .withNewTargetPort(DRIVER_LAUNCHER_SERVICE_INTERNAL_PORT)
+                .build()
+              val service = kubernetesClient.services().createNew()
+                .withNewMetadata()
+                  .withName(kubernetesAppId)
+                  .withLabels(driverKubernetesSelectors)
+                  .endMetadata()
+                .withNewSpec()
+                  .withType("NodePort")
+                  .withSelector(driverKubernetesSelectors)
+                  .withPorts(driverLauncherServicePort)
+                  .endSpec()
+                .done()
+              try {
+                sparkConf.set("spark.kubernetes.driver.service.name",
+                  service.getMetadata.getName)
+                sparkConf.setIfMissing("spark.driver.port", DEFAULT_DRIVER_PORT.toString)
+                sparkConf.setIfMissing("spark.blockmanager.port",
+                  DEFAULT_BLOCKMANAGER_PORT.toString)
+                val driverLauncher = buildDriverLauncherClient(kubernetesClient, service)
+                val ping = Retry.retry(5, 5.seconds) {
+                  driverLauncher.ping()
+                }
+                ping onFailure {
+                  case t: Throwable =>
+                    submitCompletedFuture.setException(t)
+                    kubernetesClient.services().delete(service)
+                }
+                val submitComplete = ping.flatMap { _ =>
+                  Future {
+                    sparkConf.set("spark.driver.host", pod.getStatus.getPodIP)
+                    val submitRequest = buildSubmissionRequest()
+                    driverLauncher.create(submitRequest)
+                  }
+                }
+                submitComplete onFailure {
+                  case t: Throwable =>
+                    submitCompletedFuture.setException(t)
+                    kubernetesClient.services().delete(service)
+                }
+                val adjustServicePort = submitComplete.flatMap { _ =>
+                  Future {
+                    // After submitting, adjust the service to only expose the Spark UI
+                    val uiServicePort = new ServicePortBuilder()
+                      .withName(UI_PORT_NAME)
+                      .withPort(uiPort)
+                      .withNewTargetPort(uiPort)
+                      .build()
+                    kubernetesClient.services().withName(kubernetesAppId).edit()
+                      .editSpec()
+                        .withType("ClusterIP")
+                        .withPorts(uiServicePort)
+                        .endSpec()
+                      .done
+                  }
+                }
+                adjustServicePort onSuccess {
+                  case _ =>
+                    submitCompletedFuture.set(true)
+                }
+                adjustServicePort onFailure {
+                  case throwable: Throwable =>
+                    submitCompletedFuture.setException(throwable)
+                    kubernetesClient.services().delete(service)
+                }
+              } catch {
+                case e: Throwable =>
+                  submitCompletedFuture.setException(e)
+                  try {
+                    kubernetesClient.services().delete(service)
+                  } catch {
+                    case throwable: Throwable =>
+                      logError("Submitting the job failed but failed to" +
+                        " clean up the created service.", throwable)
+                  }
+                  throw e
+              }
+            case None =>
+          }
+        }
+      }
+    }
+
+    override def onClose(e: KubernetesClientException): Unit = {
+      if (!submitCompletedFuture.isDone) {
+        submitCompletedFuture.setException(e)
+      }
+    }
+  }
+
+  private def buildSubmitFailedErrorMessage(
       kubernetesClient: DefaultKubernetesClient,
       e: TimeoutException): String = {
     val driverPod = try {
@@ -343,7 +345,7 @@ private[spark] class Client(
       s"$podStatusMessage\n\n$failedDriverContainerStatusString"
   }
 
-  private def configureContainerPorts(): Seq[ContainerPort] = {
+  private def buildContainerPorts(): Seq[ContainerPort] = {
     Seq(
       new ContainerPortBuilder()
         .withContainerPort(sparkConf.getInt("spark.driver.port", DEFAULT_DRIVER_PORT))
@@ -391,7 +393,7 @@ private[spark] class Client(
       .map(CompressionUtils.createTarGzip(_))
   }
 
-  private def getDriverLauncherClient(
+  private def buildDriverLauncherClient(
       kubernetesClient: KubernetesClient,
       service: Service): KubernetesSparkRestApi = {
     val servicePort = service

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -196,7 +196,7 @@ private[spark] class Client(
           kubernetesClient.secrets().delete(sslSecrets: _*)
         }
       }
-    })
+    }
   }
 
   private def parseDriverLaunchSslOptions(): (SSLOptions, Boolean) = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -103,7 +103,7 @@ private[spark] class Client(
     }
 
     val k8ClientConfig = k8ConfBuilder.build
-    Utils.tryWithResource(new DefaultKubernetesClient(k8ClientConfig))(kubernetesClient => {
+    Utils.tryWithResource(new DefaultKubernetesClient(k8ClientConfig)) { kubernetesClient =>
       val submitServerSecret = kubernetesClient.secrets().createNew()
         .withNewMetadata()
           .withName(secretName)
@@ -182,19 +182,19 @@ private[spark] class Client(
               throw new SparkException(finalErrorMessage, e)
           } finally {
             if (!submitSucceeded) {
-              Utils.tryLogNonFatalError({
-                kubernetesClient.pods.withName(kubernetesAppId).delete
-              })
+              Utils.tryLogNonFatalError {
+                kubernetesClient.pods.withName(kubernetesAppId).delete()
+              }
             }
           }
         }
       } finally {
-        Utils.tryLogNonFatalError({
+        Utils.tryLogNonFatalError {
           kubernetesClient.secrets().delete(submitServerSecret)
-        })
-        Utils.tryLogNonFatalError({
+        }
+        Utils.tryLogNonFatalError {
           kubernetesClient.secrets().delete(sslSecrets: _*)
-        })
+        }
       }
     })
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -109,7 +109,6 @@ private[spark] class Client(
             DRIVER_LAUNCHER_SELECTOR_LABEL -> driverLauncherSelectorValue,
             SPARK_APP_NAME_LABEL -> appName)
           ++ parsedCustomLabels).asJava
-        val selectors = Map(DRIVER_LAUNCHER_SELECTOR_LABEL -> driverLauncherSelectorValue).asJava
         val containerPorts = configureContainerPorts()
         val submitCompletedFuture = SettableFuture.create[Boolean]
         val secretDirectory = s"$SPARK_SUBMISSION_SECRET_BASE_DIR/$kubernetesAppId"
@@ -134,10 +133,11 @@ private[spark] class Client(
                     val service = kubernetesClient.services().createNew()
                       .withNewMetadata()
                         .withName(kubernetesAppId)
+                        .withLabels(resolvedSelectors)
                         .endMetadata()
                       .withNewSpec()
                         .withType("NodePort")
-                        .withSelector(selectors)
+                        .withSelector(resolvedSelectors)
                         .withPorts(driverLauncherServicePort)
                         .endSpec()
                       .done()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -96,9 +96,6 @@ private[spark] class KubernetesClusterSchedulerBackend(
     sc.getConf.getInt("spark.driver.port", DEFAULT_DRIVER_PORT),
     CoarseGrainedSchedulerBackend.ENDPOINT_NAME).toString
 
-  private def convertToEnvMode(value: String): String =
-    value.toUpperCase.map { c => if (c == '-') '_' else c }
-
   private val initialExecutors = getInitialTargetExecutorNumber(1)
 
   private def getInitialTargetExecutorNumber(defaultNumExecutors: Int = 1): Int = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -92,7 +92,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   protected var totalExpectedExecutors = new AtomicInteger(0)
 
   private val driverUrl = RpcEndpointAddress(
-    System.getenv(s"${convertToEnvMode(kubernetesDriverServiceName)}_SERVICE_HOST"),
+    sc.getConf.get("spark.driver.host"),
     sc.getConf.getInt("spark.driver.port", DEFAULT_DRIVER_PORT),
     CoarseGrainedSchedulerBackend.ENDPOINT_NAME).toString
 

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/driver/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/driver/Dockerfile
@@ -19,5 +19,14 @@ ENV SPARK_HOME /opt/spark
 
 WORKDIR /opt/spark
 
-# This class will also require setting a secret via the SPARK_APP_SECRET environment variable
-CMD exec bin/spark-class org.apache.spark.deploy.rest.kubernetes.KubernetesSparkRestServer --hostname $HOSTNAME --port $SPARK_DRIVER_LAUNCHER_SERVER_PORT --secret-file $SPARK_SUBMISSION_SECRET_LOCATION
+CMD SSL_ARGS="" && \
+    if ! [ -z ${SPARK_SUBMISSION_USE_SSL+x} ]; then SSL_ARGS="$SSL_ARGS --use-ssl $SPARK_SUBMISSION_USE_SSL"; fi && \
+    if ! [ -z ${SPARK_SUBMISSION_KEYSTORE_FILE+x} ]; then SSL_ARGS="$SSL_ARGS --keystore-file $SPARK_SUBMISSION_KEYSTORE_FILE"; fi && \
+    if ! [ -z ${SPARK_SUBMISSION_KEYSTORE_TYPE+x} ]; then SSL_ARGS="$SSL_ARGS --keystore-type $SPARK_SUBMISSION_KEYSTORE_TYPE"; fi && \
+    if ! [ -z ${SPARK_SUBMISSION_KEYSTORE_PASSWORD_FILE+x} ]; then SSL_ARGS="$SSL_ARGS --keystore-password-file $SPARK_SUBMISSION_KEYSTORE_PASSWORD_FILE"; fi && \
+    if ! [ -z ${SPARK_SUBMISSION_KEYSTORE_KEY_PASSWORD_FILE+x} ]; then SSL_ARGS="$SSL_ARGS --keystore-key-password-file $SPARK_SUBMISSION_KEYSTORE_KEY_PASSWORD_FILE"; fi && \
+    exec bin/spark-class org.apache.spark.deploy.rest.kubernetes.KubernetesSparkRestServer \
+      --hostname $HOSTNAME \
+      --port $SPARK_DRIVER_LAUNCHER_SERVER_PORT \
+      --secret-file $SPARK_SUBMISSION_SECRET_LOCATION \
+      ${SSL_ARGS}

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -106,6 +106,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.deploy.kubernetes.integrationtest
 
+import java.io.File
 import java.nio.file.Paths
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -36,7 +37,12 @@ import org.apache.spark.deploy.kubernetes.Client
 import org.apache.spark.deploy.kubernetes.integrationtest.docker.SparkDockerImageBuilder
 import org.apache.spark.deploy.kubernetes.integrationtest.minikube.Minikube
 import org.apache.spark.deploy.kubernetes.integrationtest.restapis.SparkRestApiV1
+<<<<<<< HEAD
+import org.apache.spark.deploy.kubernetes.integrationtest.sslutil.SSLUtils
+||||||| merged common ancestors
+=======
 import org.apache.spark.internal.Logging
+>>>>>>> nodeport-upload
 import org.apache.spark.status.api.v1.{ApplicationStatus, StageStatus}
 import org.apache.spark.util.Utils
 
@@ -68,6 +74,8 @@ private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
   private val NAMESPACE = UUID.randomUUID().toString.replaceAll("-", "")
   private var minikubeKubernetesClient: KubernetesClient = _
   private var clientConfig: Config = _
+  private var keyStoreFile: File = _
+  private var trustStoreFile: File = _
 
   override def beforeAll(): Unit = {
     Minikube.startMinikube()
@@ -79,6 +87,13 @@ private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
       .done()
     minikubeKubernetesClient = Minikube.getKubernetesClient.inNamespace(NAMESPACE)
     clientConfig = minikubeKubernetesClient.getConfiguration
+    val (keyStore, trustStore) = SSLUtils.generateKeyStoreTrustStorePair(
+      Minikube.getMinikubeIp,
+      "changeit",
+      "changeit",
+      "changeit")
+    keyStoreFile = keyStore
+    trustStoreFile = trustStore
   }
 
   before {
@@ -295,5 +310,33 @@ private[spark] class KubernetesSuite extends SparkFunSuite with BeforeAndAfter {
       " spark-app-name label.")
     assert(driverPodLabels.get("label1") == "label1value", "Unexpected value for label1")
     assert(driverPodLabels.get("label2") == "label2value", "Unexpected value for label2")
+  }
+
+  test("Enable SSL on the driver submit server") {
+    val args = Array(
+      "--master", s"k8s://https://${Minikube.getMinikubeIp}:8443",
+      "--deploy-mode", "cluster",
+      "--kubernetes-namespace", NAMESPACE,
+      "--name", "spark-pi",
+      "--executor-memory", "512m",
+      "--executor-cores", "1",
+      "--num-executors", "1",
+      "--upload-jars", HELPER_JAR,
+      "--class", MAIN_CLASS,
+      "--conf", s"spark.kubernetes.submit.caCertFile=${clientConfig.getCaCertFile}",
+      "--conf", s"spark.kubernetes.submit.clientKeyFile=${clientConfig.getClientKeyFile}",
+      "--conf", s"spark.kubernetes.submit.clientCertFile=${clientConfig.getClientCertFile}",
+      "--conf", "spark.kubernetes.executor.docker.image=spark-executor:latest",
+      "--conf", "spark.kubernetes.driver.docker.image=spark-driver:latest",
+      "--conf", "spark.ssl.kubernetes.driverlaunch.enabled=true",
+      "--conf", "spark.ssl.kubernetes.driverlaunch.keyStore=" +
+        s"file://${keyStoreFile.getAbsolutePath}",
+      "--conf", "spark.ssl.kubernetes.driverlaunch.keyStorePassword=changeit",
+      "--conf", "spark.ssl.kubernetes.driverlaunch.keyPassword=changeit",
+      "--conf", "spark.ssl.kubernetes.driverlaunch.trustStore=" +
+        s"file://${trustStoreFile.getAbsolutePath}",
+      "--conf", s"spark.ssl.kubernetes.driverlaunch.trustStorePassword=changeit",
+      EXAMPLES_JAR)
+    SparkSubmit.main(args)
   }
 }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
@@ -37,12 +37,7 @@ import org.apache.spark.deploy.kubernetes.Client
 import org.apache.spark.deploy.kubernetes.integrationtest.docker.SparkDockerImageBuilder
 import org.apache.spark.deploy.kubernetes.integrationtest.minikube.Minikube
 import org.apache.spark.deploy.kubernetes.integrationtest.restapis.SparkRestApiV1
-<<<<<<< HEAD
 import org.apache.spark.deploy.kubernetes.integrationtest.sslutil.SSLUtils
-||||||| merged common ancestors
-=======
-import org.apache.spark.internal.Logging
->>>>>>> nodeport-upload
 import org.apache.spark.status.api.v1.{ApplicationStatus, StageStatus}
 import org.apache.spark.util.Utils
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/sslutil/SSLUtils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/sslutil/SSLUtils.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.integrationtest.sslutil
+
+import java.io.{File, FileOutputStream}
+import java.math.BigInteger
+import java.nio.file.Files
+import java.security.{KeyPairGenerator, KeyStore, SecureRandom}
+import java.util.{Calendar, Random}
+import javax.security.auth.x500.X500Principal
+
+import org.bouncycastle.asn1.x509.{Extension, GeneralName, GeneralNames}
+import org.bouncycastle.cert.jcajce.{JcaX509CertificateConverter, JcaX509v3CertificateBuilder}
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+
+import org.apache.spark.util.Utils
+
+private[spark] object SSLUtils {
+
+  def generateKeyStoreTrustStorePair(
+      ipAddress: String,
+      keyStorePassword: String,
+      keyPassword: String,
+      trustStorePassword: String): (File, File) = {
+    val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
+    keyPairGenerator.initialize(512)
+    val keyPair = keyPairGenerator.generateKeyPair()
+    val selfPrincipal = new X500Principal(s"cn=$ipAddress")
+    val currentDate = Calendar.getInstance
+    val validForOneHundredYears = Calendar.getInstance
+    validForOneHundredYears.add(Calendar.YEAR, 100)
+    val certificateBuilder = new JcaX509v3CertificateBuilder(
+      selfPrincipal,
+      new BigInteger(4096, new Random()),
+      currentDate.getTime,
+      validForOneHundredYears.getTime,
+      selfPrincipal,
+      keyPair.getPublic)
+    certificateBuilder.addExtension(Extension.subjectAlternativeName, false,
+      new GeneralNames(new GeneralName(GeneralName.iPAddress, ipAddress)))
+    val signer = new JcaContentSignerBuilder("SHA1WithRSA")
+      .setSecureRandom(new SecureRandom())
+      .build(keyPair.getPrivate)
+    val bcCertificate = certificateBuilder.build(signer)
+    val jcaCertificate = new JcaX509CertificateConverter().getCertificate(bcCertificate)
+    val keyStore = KeyStore.getInstance("JKS")
+    keyStore.load(null, null)
+    keyStore.setKeyEntry("key", keyPair.getPrivate,
+      keyPassword.toCharArray, Array(jcaCertificate))
+    val tempDir = Files.createTempDirectory("temp-ssl-stores").toFile()
+    tempDir.deleteOnExit()
+    val keyStoreFile = new File(tempDir, "keyStore.jks")
+    Utils.tryWithResource(new FileOutputStream(keyStoreFile)) {
+      keyStore.store(_, keyStorePassword.toCharArray)
+    }
+    val trustStore = KeyStore.getInstance("JKS")
+    trustStore.load(null, null)
+    trustStore.setCertificateEntry("key", jcaCertificate)
+    val trustStoreFile = new File(tempDir, "trustStore.jks")
+    Utils.tryWithResource(new FileOutputStream(trustStoreFile)) {
+      trustStore.store(_, trustStorePassword.toCharArray)
+    }
+    (keyStoreFile, trustStoreFile)
+  }
+
+}


### PR DESCRIPTION
- Expose the driver-submission service on NodePort and contact that as
opposed to going through the API server proxy
- Restrict the ports that are exposed on the service to only the driver
submission service when uploading content and then only the Spark UI
after the job has started
* Add configuration for SSL

Closes #24 and is a prerequisite for #28.