### PR TITLE
Make pod name unique using the submission timestamp

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -56,10 +56,10 @@ private[spark] class Client(
   private val master = rawMaster.replaceFirst("k8s://", "")
 
   private val launchTime = System.currentTimeMillis
-  private val kubernetesAppId = sparkConf.getOption("spark.app.name")
+  private val appName = sparkConf.getOption("spark.app.name")
     .orElse(sparkConf.getOption("spark.app.id"))
-    .getOrElse(s"spark-$launchTime")
-
+    .getOrElse("spark")
+  private val kubernetesAppId = s"$appName-$launchTime"
   private val secretName = s"spark-submission-server-secret-$kubernetesAppId"
   private val driverLauncherSelectorValue = s"driver-launcher-$launchTime"
   private val driverDockerImage = sparkConf.get(


### PR DESCRIPTION
Addressing part of https://github.com/apache-spark-on-k8s/spark/issues/17
This should ensure we create unique driver/service names in every invocation.