### PR TITLE
Support spark.driver.extraJavaOptions

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/KubernetesSparkRestServer.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/KubernetesSparkRestServer.scala
@@ -173,6 +173,10 @@ private[spark] class KubernetesSparkRestServer(
                 val driverMemory = resolvedSparkProperties.getOrElse("spark.driver.memory", "1g")
                 command += s"-Xms$driverMemory"
                 command += s"-Xmx$driverMemory"
+                val extraJavaOpts = resolvedSparkProperties.get("spark.driver.extraJavaOptions")
+                  .map(Utils.splitCommandString)
+                  .getOrElse(Seq.empty)
+                command ++= extraJavaOpts
                 command += mainClass
                 command ++= appArgs
                 val pb = new ProcessBuilder(command: _*).inheritIO()


### PR DESCRIPTION
Supports extra JVM options to pass to the driver command line. spark.driver.extraJavaOptions is an existing config key (documented [here](http://spark.apache.org/docs/latest/configuration.html)) and commonly used to pass additional JVM GC settings, etc.