### PR TITLE
Use "extraScalaTestArgs" to pass extra options to scalatest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2096,7 +2096,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraTestArgLine}</argLine>
             <stderr/>
             <environmentVariables>
               <!--

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
     <CodeCacheSize>512m</CodeCacheSize>
-    <extraTestArgLine></extraTestArgLine>
+    <extraScalaTestArgs></extraScalaTestArgs>
   </properties>
   <repositories>
     <repository>
@@ -2097,7 +2097,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraTestArgLine}</argLine>
+            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraScalaTestArgs}</argLine>
             <stderr/>
             <environmentVariables>
               <!--

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
     <CodeCacheSize>512m</CodeCacheSize>
+    <extraTestArgLine></extraTestArgLine>
   </properties>
   <repositories>
     <repository>

--- a/resource-managers/kubernetes/README.md
+++ b/resource-managers/kubernetes/README.md
@@ -51,6 +51,20 @@ Afterwards, the integration tests can be executed with Maven or your IDE. Note t
 `pre-integration-test` phase must be run every time the Spark main code changes. When running tests from the
 command line, the `pre-integration-test` phase should automatically be invoked if the `integration-test` phase is run.
 
+# Preserve the Minikube VM
+
+The integration tests make use of [Minikube](https://github.com/kubernetes/minikube), which fires up a virtual machine
+and setup a single-node kubernetes cluster within it. By default the vm is destroyed after the tests are finished.
+If you want to preserve the vm, e.g. to reduce the running time of tests during development, you can pass the property
+`spark.docker.test.persistMinikube` to the test process:
+
+```sh
+build/mvn integration-test \
+    -Pkubernetes -Pkubernetes-integration-tests \
+    -pl resource-managers/kubernetes/integration-tests -am \
+    -DextraScalaTestArgs=-Dspark.docker.test.persistMinikube=true
+```
+
 # Usage Guide
 
 See the [usage guide](../../docs/running-on-kubernetes.md) for more information.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Because the "argLine" option of scalatest is set in pom.xml and we can't
overwrite it from the command line.

Ref apache-spark-on-k8s/spark#37

## How was this patch tested?

When I use this option to set `spark.docker.test.persistMinikube` to `true`, the minikube vm wasn't deleted after the integration tests, which is expected.

```sh
build/mvn -Pkubernetes -Pkubernetes-integration-tests \
          -pl resource-managers/kubernetes/integration-tests -am \
          -DwildcardSuites=org.apache.spark.deploy.kubernetes.integrationtest.KubernetesSuite \
          -DextraScalaTestArgs=-Dspark.docker.test.persistMinikube=true \
          integration-test
```