### PR TITLE
Introduce blocking submit to kubernetes by default

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -207,6 +207,8 @@ private[spark] class Client(
             logInfo(s"Waiting for application $kubernetesAppId to finish...")
             driverPodCompletedLatch.await()
             logInfo(s"Application $kubernetesAppId finished.")
+          } else {
+            logInfo(s"Application $kubernetesAppId launched.")
           }
         }
       } finally {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -121,8 +121,10 @@ private[spark] class Client(
 
         // start outer watch for status logging of driver pod
         val driverPodCompletedLatch = new CountDownLatch(1)
+        // only enable interval logging if in waitForAppCompletion mode
+        val loggingInterval = if (waitForAppCompletion) sparkConf.get(REPORT_INTERVAL) else 0
         val loggingWatch = new LoggingPodStatusWatcher(driverPodCompletedLatch, kubernetesAppId,
-                                                       sparkConf.get(REPORT_INTERVAL))
+                                                       loggingInterval)
         Utils.tryWithResource(kubernetesClient
             .pods()
             .withLabels(driverKubernetesSelectors)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -208,7 +208,7 @@ private[spark] class Client(
             driverPodCompletedLatch.await()
             logInfo(s"Application $kubernetesAppId finished.")
           } else {
-            logInfo(s"Application $kubernetesAppId launched.")
+            logInfo(s"Application $kubernetesAppId successfully launched.")
           }
         }
       } finally {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -26,7 +26,7 @@ import com.google.common.base.Charsets
 import com.google.common.io.Files
 import com.google.common.util.concurrent.SettableFuture
 import io.fabric8.kubernetes.api.model._
-import io.fabric8.kubernetes.client.{ConfigBuilder => KConfigBuilder, DefaultKubernetesClient, KubernetesClient, KubernetesClientException, Watcher}
+import io.fabric8.kubernetes.client.{ConfigBuilder => K8SConfigBuilder, DefaultKubernetesClient, KubernetesClient, KubernetesClientException, Watcher}
 import io.fabric8.kubernetes.client.Watcher.Action
 import org.apache.commons.codec.binary.Base64
 import scala.collection.JavaConverters._
@@ -65,7 +65,7 @@ private[spark] class Client(
   private val uiPort = sparkConf.getInt("spark.ui.port", DEFAULT_UI_PORT)
   private val driverSubmitTimeoutSecs = sparkConf.get(KUBERNETES_DRIVER_SUBMIT_TIMEOUT)
 
-  private val fireAndForget: Boolean = !sparkConf.get(WAIT_FOR_APP_COMPLETION);
+  private val fireAndForget: Boolean = !sparkConf.get(WAIT_FOR_APP_COMPLETION)
 
   private val secretBase64String = {
     val secretBytes = new Array[Byte](128)
@@ -83,7 +83,7 @@ private[spark] class Client(
   def run(): Unit = {
     val (driverSubmitSslOptions, isKeyStoreLocalFile) = parseDriverSubmitSslOptions()
     val parsedCustomLabels = parseCustomLabels(customLabels)
-    var k8ConfBuilder = new KConfigBuilder()
+    var k8ConfBuilder = new K8SConfigBuilder()
       .withApiVersion("v1")
       .withMasterUrl(master)
       .withNamespace(namespace)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -188,6 +188,7 @@ private[spark] class Client(
             try {
               submitCompletedFuture.get(driverSubmitTimeoutSecs, TimeUnit.SECONDS)
               submitSucceeded = true
+              logInfo(s"Finished launching local resources to application $kubernetesAppId")
             } catch {
               case e: TimeoutException =>
                 val finalErrorMessage: String = buildSubmitFailedErrorMessage(kubernetesClient, e)
@@ -404,6 +405,8 @@ private[spark] class Client(
                   Future {
                     sparkConf.set("spark.driver.host", pod.getStatus.getPodIP)
                     val submitRequest = buildSubmissionRequest()
+                    logInfo(s"Submitting local resources to driver pod for application " +
+                      s"$kubernetesAppId ...")
                     driverSubmitter.submitApplication(submitRequest)
                   }
                 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
@@ -69,7 +69,7 @@ private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: CountDownL
 
   override def onClose(e: KubernetesClientException): Unit = {
     scheduler.shutdown()
-    logInfo(s"Stopped watching application $appId with last-observed phase $phase")
+    logDebug(s"Stopped watching application $appId with last-observed phase $phase")
   }
 
   private def logShortStatus() = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
@@ -32,7 +32,8 @@ import org.apache.spark.internal.Logging
  *
  * @param podCompletedFuture a CountDownLatch that is set to true when the watched pod finishes
  * @param appId
- * @param interval ms between each state request
+ * @param interval ms between each state request.  If set to 0 or a negative number, the periodic
+ *                 logging will be disabled.
  */
 private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: CountDownLatch,
                                                   appId: String,
@@ -44,7 +45,9 @@ private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: CountDownL
   private val logRunnable: Runnable = new Runnable {
     override def run() = logShortStatus()
   }
-  scheduler.scheduleWithFixedDelay(logRunnable, 0, interval, TimeUnit.MILLISECONDS)
+  if (interval > 0) {
+    scheduler.scheduleWithFixedDelay(logRunnable, 0, interval, TimeUnit.MILLISECONDS)
+  }
 
   private var pod: Option[Pod] = Option.empty
   private var prevPhase: String = null

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
@@ -86,13 +86,13 @@ private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: SettableFu
       // pod metadata
       ("pod name", pod.getMetadata.getName()),
       ("namespace", pod.getMetadata.getNamespace()),
-      ("labels", pod.getMetadata.getLabels().asScala.mkString(",")),
+      ("labels", pod.getMetadata.getLabels().asScala.mkString(", ")),
       ("pod uid", pod.getMetadata.getUid),
       ("creation time", pod.getMetadata.getCreationTimestamp()),
 
       // spec details
       ("service account name", pod.getSpec.getServiceAccountName()),
-      ("volumes", pod.getSpec.getVolumes().asScala.map(_.getName).mkString(",")),
+      ("volumes", pod.getSpec.getVolumes().asScala.map(_.getName).mkString(", ")),
       ("node name", pod.getSpec.getNodeName()),
 
       // status
@@ -101,7 +101,7 @@ private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: SettableFu
         pod.getStatus.getContainerStatuses()
             .asScala
             .map(_.getImage)
-            .mkString(",")),
+            .mkString(", ")),
       ("phase", pod.getStatus.getPhase())
     )
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
@@ -69,7 +69,7 @@ private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: CountDownL
 
   override def onClose(e: KubernetesClientException): Unit = {
     scheduler.shutdown()
-    logInfo(s"Application $appId ended with final phase $phase")
+    logInfo(s"Stopped watching application $appId with last-observed phase $phase")
   }
 
   private def logShortStatus() = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/PodStateMonitor.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/PodStateMonitor.scala
@@ -34,11 +34,11 @@ private[kubernetes] class PodStateMonitor(client: DefaultKubernetesClient,
                       interval: Long) extends Logging {
 
   /**
-    * Log the state of the application until it finishes, either successfully or due to a
-    * failure, logging status throughout and on every state change.
-    *
-    * When the application finishes, returns its final state, either "Succeeded" or "Failed".
-    */
+   * Log the state of the application until it finishes, either successfully or due to a
+   * failure, logging status throughout and on every state change.
+   *
+   * When the application finishes, returns its final state, either "Succeeded" or "Failed".
+   */
   def monitorToCompletion(): String = {
 
     var previousPhase: String = null

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/PodStateMonitor.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/PodStateMonitor.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes
+
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.DefaultKubernetesClient
+
+import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
+
+/**
+ * A monitor for a running Kubernetes application, logging on state change and interval.
+ *
+ * @param client Kubernetes client
+ * @param appId
+ * @param interval ms between each state request
+ */
+private[kubernetes] class PodStateMonitor(client: DefaultKubernetesClient,
+                      appId: String,
+                      interval: Long) extends Logging {
+
+  /**
+    * Log the state of the application until it finishes, either successfully or due to a
+    * failure, logging status throughout and on every state change.
+    *
+    * When the application finishes, returns its final state, either "Succeeded" or "Failed".
+    */
+  def monitorToCompletion(): String = {
+
+    var previousPhase: String = null
+
+    while (true) {
+      Thread.sleep(interval)
+
+      val podState = requestCurrentPodState()
+      val phase = podState.getStatus().getPhase()
+
+      // log a short message every interval, plus full details on every state change
+      logInfo(s"Application status for $appId (phase: $phase)")
+      if (previousPhase != phase) {
+        logInfo("Phase changed, new state: " + podState)
+      }
+
+      // terminal state -- return
+      if (phase == "Succeeded" || phase == "Failed") {
+        return phase
+      }
+
+      previousPhase = phase
+    }
+
+    // Never reached, but keeps compiler happy
+    throw new SparkException("While loop is depleted! This should never happen...")
+  }
+
+  private def requestCurrentPodState(): Pod = {
+    client.pods().withName(appId).get()
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/PodStateMonitor.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/PodStateMonitor.scala
@@ -16,13 +16,13 @@
  */
 package org.apache.spark.deploy.kubernetes
 
+import scala.collection.JavaConverters._
+
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.client.DefaultKubernetesClient
 
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
-
-import scala.collection.JavaConverters._
 
 /**
  * A monitor for a running Kubernetes application, logging on state change and interval.

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
@@ -176,8 +176,7 @@ package object config {
       .createOptional
 
   private[spark] val WAIT_FOR_APP_COMPLETION =
-    ConfigBuilder(
-      "spark.kubernetes.submit.waitAppCompletion")
+    ConfigBuilder("spark.kubernetes.submit.waitAppCompletion")
       .doc(
         """
           | In cluster mode, whether to wait for the application to finish before exiting the

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
@@ -174,4 +174,24 @@ package object config {
       .internal()
       .stringConf
       .createOptional
+
+  private[spark] val WAIT_FOR_APP_COMPLETION =
+    ConfigBuilder(
+      "spark.kubernetes.submit.waitAppCompletion")
+      .doc(
+        """
+          | In cluster mode, whether to wait for the application to finish before exiting the
+          | launcher process.
+        """.stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
+  private[spark] val REPORT_INTERVAL =
+    ConfigBuilder("spark.kubernetes.report.interval")
+      .doc(
+        """
+          | Interval between reports of the current app status in cluster mode.
+        """.stripMargin)
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("1s")
 }


### PR DESCRIPTION
Fixes #46 

Two new configuration settings, modeled off the equivalent spark.yarn... settings:
- spark.kubernetes.submit.waitAppCompletion
- spark.kubernetes.report.interval