### PR TITLE
Reduce pre-integration-test runtime

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy
 
-import java.io.{File, PrintStream}
+import java.io.File
 import java.lang.reflect.{InvocationTargetException, Modifier, UndeclaredThrowableException}
 import java.net.URL
 import java.security.PrivilegedExceptionAction
@@ -475,7 +475,8 @@ object SparkSubmit extends CommandLineUtils {
       OptionAssigner(args.files, LOCAL | STANDALONE | MESOS, ALL_DEPLOY_MODES,
         sysProp = "spark.files"),
       OptionAssigner(args.jars, LOCAL, CLIENT, sysProp = "spark.jars"),
-      OptionAssigner(args.jars, STANDALONE | MESOS, ALL_DEPLOY_MODES, sysProp = "spark.jars"),
+      OptionAssigner(args.jars, STANDALONE | MESOS | KUBERNETES, ALL_DEPLOY_MODES,
+        sysProp = "spark.jars"),
       OptionAssigner(args.driverMemory, STANDALONE | MESOS | YARN, CLUSTER,
         sysProp = "spark.driver.memory"),
       OptionAssigner(args.driverCores, STANDALONE | MESOS | YARN, CLUSTER,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -61,7 +61,7 @@ private[spark] class Client(
   private val sslSecretsDirectory = s"$DRIVER_CONTAINER_SECRETS_BASE_DIR/$kubernetesAppId-ssl"
   private val sslSecretsName = s"$SUBMISSION_SSL_SECRETS_PREFIX-$kubernetesAppId"
   private val driverDockerImage = sparkConf.get(DRIVER_DOCKER_IMAGE)
-  private val uploadedJars = sparkConf.get(KUBERNETES_DRIVER_UPLOAD_JARS)
+  private val uploadedJars = sparkConf.get(KUBERNETES_DRIVER_UPLOAD_JARS).filter(_.nonEmpty)
   private val uiPort = sparkConf.getInt("spark.ui.port", DEFAULT_UI_PORT)
   private val driverSubmitTimeoutSecs = sparkConf.get(KUBERNETES_DRIVER_SUBMIT_TIMEOUT)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/KubernetesSparkRestServer.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/KubernetesSparkRestServer.scala
@@ -27,7 +27,7 @@ import org.apache.commons.codec.binary.Base64
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.{SecurityManager, SPARK_VERSION => sparkVersion, SparkConf, SparkException, SSLOptions}
+import org.apache.spark.{SecurityManager, SPARK_VERSION => sparkVersion, SparkConf, SSLOptions}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.rest._
 import org.apache.spark.util.{ShutdownHookManager, ThreadUtils, Utils}
@@ -174,8 +174,7 @@ private[spark] class KubernetesSparkRestServer(
                 val sparkJars = new File(sparkHome, "jars").listFiles().map(_.getAbsolutePath)
                 val driverClasspath = driverExtraClasspath ++
                   resolvedJars ++
-                  sparkJars ++
-                  Array(appResourcePath)
+                  sparkJars
                 val resolvedSparkProperties = new mutable.HashMap[String, String]
                 resolvedSparkProperties ++= sparkProperties
                 resolvedSparkProperties("spark.jars") = resolvedJars.mkString(",")

--- a/resource-managers/kubernetes/docker-minimal-bundle/pom.xml
+++ b/resource-managers/kubernetes/docker-minimal-bundle/pom.xml
@@ -39,14 +39,24 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-assembly_${scala.binary.version}</artifactId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
-      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-examples_${scala.binary.version}</artifactId>
+      <artifactId>spark-kubernetes-integration-tests-spark-jobs_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-kubernetes-integration-tests-spark-jobs-helpers_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -107,38 +117,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <!-- Include other profiles from the assembly. -->
-  <profiles>
-    <profile>
-      <id>hive</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive_${scala.binary.version}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>hive-thriftserver</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>spark-ganglia-lgpl</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-ganglia-lgpl_${scala.binary.version}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/driver-assembly.xml
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/driver-assembly.xml
@@ -66,11 +66,6 @@
       <unpack>false</unpack>
       <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>
-      <excludes>
-        <exclude>org.apache.spark:spark-assembly_${scala.binary.version}:pom</exclude>
-        <exclude>org.spark-project.spark:unused</exclude>
-        <exclude>org.apache.spark:spark-examples_${scala.binary.version}</exclude>
-      </excludes>
     </dependencySet>
     <dependencySet>
       <outputDirectory>examples/jars</outputDirectory>
@@ -79,7 +74,8 @@
       <scope>provided</scope>
       <useProjectArtifact>false</useProjectArtifact>
       <includes>
-        <include>org.apache.spark:spark-examples_${scala.binary.version}:jar</include>
+        <include>org.apache.spark:spark-kubernetes-integration-tests-spark-jobs_${scala.binary.version}:jar</include>
+        <include>org.apache.spark:spark-kubernetes-integration-tests-spark-jobs-helpers_${scala.binary.version}:jar</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/executor-assembly.xml
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/executor-assembly.xml
@@ -75,11 +75,6 @@
       <unpack>false</unpack>
       <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>
-      <excludes>
-        <exclude>org.apache.spark:spark-assembly_${scala.binary.version}:pom</exclude>
-        <exclude>org.spark-project.spark:unused</exclude>
-        <exclude>org.apache.spark:spark-examples_${scala.binary.version}</exclude>
-      </excludes>
     </dependencySet>
     <dependencySet>
       <outputDirectory>examples/jars</outputDirectory>
@@ -88,7 +83,8 @@
       <scope>provided</scope>
       <useProjectArtifact>false</useProjectArtifact>
       <includes>
-        <include>org.apache.spark:spark-examples_${scala.binary.version}:jar</include>
+        <include>org.apache.spark:spark-kubernetes-integration-tests-spark-jobs_${scala.binary.version}:jar</include>
+        <include>org.apache.spark:spark-kubernetes-integration-tests-spark-jobs-helpers_${scala.binary.version}:jar</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -69,6 +69,18 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-kubernetes-integration-tests-spark-jobs_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-kubernetes-integration-tests-spark-jobs-helpers_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
docker-minimal-bundle now only includes the core, kubernetes, and sql modules of the
Spark project. The Dockerfiles are still valid for the main distribution
which includes all of the modules.

A small bug was found and fixed on the way in using jars that are mounted on the
docker image.

Closes #66 