### PR TITLE
Configure Travis to run K8s integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,17 @@
 sudo: required
 dist: trusty
 
-# 2. Choose language and target JDKs for parallel builds.
+# 2. Choose language, target JDKs, and tests for parallel builds
 language: java
-jdk:
-  - oraclejdk7
-  - oraclejdk8
+matrix:
+  include:
+  - jdk: oraclejdk7
+    env: TEST_TO_RUN=lint-java
+  - jdk: oraclejdk8
+    env: TEST_TO_RUN=lint-scala
+  - jdk: oraclejdk8
+    env: TEST_TO_RUN=kubernetes-integration
+    install: true # skips the install step
 
 # 3. Setup cache directory for SBT and Maven.
 cache:
@@ -41,11 +47,29 @@ cache:
 notifications:
   email: false
 
-# 5. Run maven install before running lint-java.
+# 5. Run maven install before running lint.
 install:
   - export MAVEN_SKIP_RC=1
   - build/mvn -T 4 -q -DskipTests -Pmesos -Pyarn -Phadoop-2.3 -Pkubernetes -Pkinesis-asl -Phive -Phive-thriftserver install
 
-# 6. Run lint-java.
+# 6. Run test
 script:
-  - dev/lint-java
+  - if [[ $TEST_TO_RUN == "lint-java" ]] ; then
+      dev/lint-java;
+    else
+      echo "lint-java SKIPPED";
+    fi
+  - if [[ $TEST_TO_RUN == "lint-scala" ]] ; then
+      dev/lint-scala;
+    else
+      echo "lint-scala SKIPPED";
+    fi
+  - |
+    if [[ $TEST_TO_RUN ==  "kubernetes-integration" ]]; then
+      export MAVEN_SKIP_RC=true;
+      build/mvn -B integration-test -Pkubernetes -Pkubernetes-integration-tests \
+        -pl resource-managers/kubernetes/integration-tests -am -Dtest=none \
+        -DwildcardSuites=org.apache.spark.deploy.kubernetes.integrationtest.KubernetesSuite ;
+    else
+      echo "kubernetes-integration SKIPPED";
+    fi


### PR DESCRIPTION
Modify Travis configuration to run k8s integration test with every pull request. In addition, made a change to run lint-scala along with lint-java.

The integration test seems to be failing currently due to an un-related issue. We'll need to fix that before this ratchet is enabled.