### PR TITLE
Fix NPE around unschedulable pod specs

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -570,7 +570,8 @@ private[spark] class Client(
       .filter(_.getName == SUBMISSION_SERVER_PORT_NAME)
       .head.getNodePort
     val nodeUrls = kubernetesClient.nodes.list.getItems.asScala
-      .filterNot(_.getSpec.getUnschedulable)
+      .filterNot(node => node.getSpec.getUnschedulable != null &&
+        node.getSpec.getUnschedulable)
       .flatMap(_.getStatus.getAddresses.asScala.map(address => {
         s"$urlScheme://${address.getAddress}:$servicePort"
       })).toArray


### PR DESCRIPTION
Fixes #77 

This is another instance where our minikube ete tests aren't sufficient to catch problems running on live clusters, like the kubeadm-created one I've been testing with.