### PR TITLE
Small refactor of the pod status watcher

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -125,8 +125,9 @@ private[spark] class Client(
         val driverPodCompletedLatch = new CountDownLatch(1)
         // only enable interval logging if in waitForAppCompletion mode
         val loggingInterval = if (waitForAppCompletion) sparkConf.get(REPORT_INTERVAL) else 0
-        val loggingWatch = new LoggingPodStatusWatcher(driverPodCompletedLatch, kubernetesAppId,
-                                                       loggingInterval)
+        val loggingWatch = new LoggingPodStatusWatcher(kubernetesAppId,
+                                                       loggingInterval,
+                                                       driverPodCompletedLatch.countDown)
         Utils.tryWithResource(kubernetesClient
             .pods()
             .withLabels(driverKubernetesSelectors)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
@@ -35,9 +35,9 @@ import org.apache.spark.internal.Logging
  * @param interval ms between each state request.  If set to 0 or a negative number, the periodic
  *                 logging will be disabled.
  */
-private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: CountDownLatch,
-                                                  appId: String,
-                                                  interval: Long)
+private[kubernetes] class LoggingPodStatusWatcher(appId: String,
+                                                  interval: Long,
+                                                  completionFunc: => Unit)
     extends Watcher[Pod] with Logging {
 
   // start timer for periodic logging
@@ -63,7 +63,7 @@ private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: CountDownL
     prevPhase = phase
 
     if (phase == "Succeeded" || phase == "Failed") {
-      podCompletedFuture.countDown()
+      completionFunc
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pass a callback function instead of a count down latch to the pod status watcher. This would make it more generic (e.g. in the future we may want to add extra logic when the pod finishes).

## How was this patch tested?

Existing tests.