### PR TITLE
Trigger scalatest plugin in the integration-test phase

### DIFF
--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -222,7 +222,6 @@
              See copy-test-spark-jobs execution of maven-dependency-plugin above. -->
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <configuration>...</configuration>
         <executions>
           <execution>
             <id>test</id>
@@ -230,6 +229,8 @@
               <goal>test</goal>
             </goals>
             <configuration>
+              <!-- The negative pattern below prevents integration tests such as
+                   KubernetesSuite from running in the test phase. -->
               <suffixes>(?&lt;!Suite)</suffixes>
             </configuration>
           </execution>
@@ -239,9 +240,6 @@
             <goals>
               <goal>test</goal>
             </goals>
-            <configuration>
-              <suffixes>(?&lt;=Suite)</suffixes>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -216,6 +216,35 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <!-- Triggers scalatest plugin in the integration-test phase instead of
+             the test phase, so that test jobs are copied over beforehand.
+             See copy-test-spark-jobs execution of maven-dependency-plugin above. -->
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>...</configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <suffixes>(?&lt;!Suite)</suffixes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>integration-test</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <suffixes>(?&lt;=Suite)</suffixes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
   </build>


### PR DESCRIPTION
@ash211 @cvpatel @ssuchter 

## What changes were proposed in this pull request?

Currently, the kubernetes integration test runs in the maven test phase and fails because the test jobs and other jars are missing in the target dir. (See #74)  Those jars are supposed to be copied in the pre-integration-test phase, which is after the test phase.

This change fixes the issue by triggering the scalatest plugin in the integration-test phase. The target directory now has the needed jars.


## How was this patch tested?

Ran the integration test build command and saw it passed the previous failing point.
```
$ build/mvn -B clean integration-test -Pkubernetes -Pkubernetes-integration-tests -pl resource-managers/kubernetes/integration-tests -am -Dtest=none -DwildcardSuites=org.apache.spark.deploy.kubernetes.integrationtest.KubernetesSuite
```