### PR TITLE
Parse results of minikube status more rigorously

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/minikube/Minikube.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/minikube/Minikube.scala
@@ -19,6 +19,7 @@ package org.apache.spark.deploy.kubernetes.integrationtest.minikube
 import java.io.{BufferedReader, InputStreamReader}
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
 import javax.net.ssl.X509TrustManager
 
 import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
@@ -58,6 +59,7 @@ private[spark] object Minikube extends Logging {
   def getMinikubeIp: String = synchronized {
     assert(MINIKUBE_EXECUTABLE_DEST.exists(), EXPECTED_DOWNLOADED_MINIKUBE_MESSAGE)
     val outputs = executeMinikube("ip")
+      .filter(_.matches("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"))
     assert(outputs.size == 1, "Unexpected amount of output from minikube ip")
     outputs.head
   }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/minikube/Minikube.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/minikube/Minikube.scala
@@ -64,7 +64,10 @@ private[spark] object Minikube extends Logging {
 
   def getMinikubeStatus: MinikubeStatus.Value = synchronized {
     assert(MINIKUBE_EXECUTABLE_DEST.exists(), EXPECTED_DOWNLOADED_MINIKUBE_MESSAGE)
-    val statusString = executeMinikube("status").head.replaceFirst("minikubeVM: ", "")
+    val statusString = executeMinikube("status")
+      .filter(_.contains("minikubeVM: "))
+      .head
+      .replaceFirst("minikubeVM: ", "")
     MinikubeStatus.unapply(statusString)
         .getOrElse(throw new IllegalStateException(s"Unknown status $statusString"))
   }


### PR DESCRIPTION
Fixes #96 

Prior code assumes the minikubeVM status line is always the first row output
from minikube status, and it is not when the version upgrade notifier prints
an upgrade suggestion message.