### PR TITLE
Truncate k8s hostnames to be no longer than 63 characters

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -155,13 +155,12 @@ private[spark] class KubernetesClusterSchedulerBackend(
   }
 
   private def allocateNewExecutorPod(): (String, Pod) = {
-    val executorKubernetesId = UUID.randomUUID().toString.replaceAll("-", "")
     val executorId = EXECUTOR_ID_COUNTER.incrementAndGet().toString
     val name = s"${applicationId()}-exec-$executorId"
 
     // hostname must be no longer than 63 characters, so take the last 63 characters of the pod
     // name as the hostname.  This preserves uniqueness since the end of name contains
-    // executorKubernetesId and applicationId
+    // executorId and applicationId
     val hostname = name.substring(Math.max(0, name.length - 63))
 
     val selectors = Map(SPARK_EXECUTOR_ID_LABEL -> executorId,
@@ -196,7 +195,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
           .build()
       })
     try {
-      (executorKubernetesId, kubernetesClient.pods().createNew()
+      (executorId, kubernetesClient.pods().createNew()
         .withNewMetadata()
           .withName(name)
           .withLabels(selectors)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -157,7 +157,13 @@ private[spark] class KubernetesClusterSchedulerBackend(
   private def allocateNewExecutorPod(): (String, Pod) = {
     val executorKubernetesId = UUID.randomUUID().toString.replaceAll("-", "")
     val executorId = EXECUTOR_ID_COUNTER.incrementAndGet().toString
-    val name = s"${applicationId()}-exec-$executorKubernetesId"
+    val name = s"${applicationId()}-exec-$executorId"
+
+    // hostname must be no longer than 63 characters, so take the last 63 characters of the pod
+    // name as the hostname.  This preserves uniqueness since the end of name contains
+    // executorKubernetesId and applicationId
+    val hostname = name.substring(Math.max(0, name.length - 63))
+
     val selectors = Map(SPARK_EXECUTOR_ID_LABEL -> executorId,
       SPARK_APP_ID_LABEL -> applicationId()).asJava
     val executorMemoryQuantity = new QuantityBuilder(false)
@@ -204,6 +210,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
           .endOwnerReference()
         .endMetadata()
         .withNewSpec()
+          .withHostname(hostname)
           .addNewContainer()
             .withName(s"executor")
             .withImage(executorDockerImage)


### PR DESCRIPTION
Fixes #101 