### PR TITLE
[WIP] Use spark.jars and spark.files instead of k8s-specific config

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
@@ -91,30 +91,6 @@ package object config {
       .stringConf
       .createWithDefault("default")
 
-  private[spark] val KUBERNETES_DRIVER_UPLOAD_JARS =
-    ConfigBuilder("spark.kubernetes.driver.uploads.jars")
-      .doc("""
-          | Comma-separated list of jars to send to the driver and
-          | all executors when submitting the application in cluster
-          | mode.
-        """.stripMargin)
-      .stringConf
-      .createOptional
-
-  private[spark] val KUBERNETES_DRIVER_UPLOAD_FILES =
-    ConfigBuilder("spark.kubernetes.driver.uploads.files")
-      .doc("""
-          | Comma-separated list of files to send to the driver and
-          | all executors when submitting the application in cluster
-          | mode. The files are added in a flat hierarchy to the
-          | current working directory of the driver, having the same
-          | names as the names of the original files. Note that two
-          | files with the same name cannot be added, even if they
-          | were in different source directories on the client disk.
-        """.stripMargin)
-      .stringConf
-      .createOptional
-
   // Note that while we set a default for this when we start up the
   // scheduler, the specific default value is dynamically determined
   // based on the executor memory.


### PR DESCRIPTION
Fixes #92 

This brings spark.jars and spark.files in line with the behavior of YARN and
other cluster managers.

Specifically now, the following schemes are supported:

- local:// is a container-local file assumed to be present on both driver and
  executor containers
- container:// is a synonym for local://
- file:// is a submitter-local file that's uploaded to the driver
- a no-scheme path is treated as if it had the file:// scheme

Filenames of spark.files are required to be unique since they are all placed
in the current working directory of the driver and executors.  spark.jars does
not have this restriction -- they are given a unique suffix and placed in a
separate folder from the current working directory and added to the driver
classpath.