### PR TITLE
Bumping up kubernetes-client version to fix GKE and local proxy

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -51,7 +51,7 @@ connect without SSL on a different port, the master would be set to `k8s://http:
 
 Note that applications can currently only be executed in cluster mode, where the driver and its executors are running on
 the cluster.
- 
+
 ### Adding Other JARs
  
 Spark allows users to provide dependencies that are bundled into the driver's Docker image, or that are on the local
@@ -149,6 +149,29 @@ container image's disk. Thus `spark.ssl.kubernetes.submit.keyStore` can be a URI
 or `container:`. A scheme of `file:` corresponds to the keyStore being located on the client machine; it is mounted onto
 the driver container as a [secret volume](https://kubernetes.io/docs/user-guide/secrets/). When the URI has the scheme
 `container:`, the file is assumed to already be on the container's disk at the appropriate path.
+
+### Kubernetes Clusters and the authenticated proxy endpoint
+
+Spark-submit also supports submission through the
+local kubectl proxy](https://kubernetes.io/docs/user-guide/connecting-to-applications-proxy/). One can use the
+authenticating proxy to communicate with the api server directly without passing credentials to spark-submit.
+For example, if our local proxy were listening on port 8001, we would have our submission looking like the following:
+
+    bin/spark-submit \
+      --deploy-mode cluster \
+      --class org.apache.spark.examples.SparkPi \
+      --master k8s://http://127.0.0.1:8001 \
+      --kubernetes-namespace default \
+      --conf spark.executor.instances=5 \
+      --conf spark.app.name=spark-pi \
+      --conf spark.kubernetes.driver.docker.image=registry-host:5000/spark-driver:latest \
+      --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest \
+      examples/jars/spark_examples_2.11-2.2.0.jar
+
+This mechanism can also be useful when we have authentication schemes that the client library does not support
+completely. The default authentication schemes, using X509 Client Certs and oauth tokens (gce), are currently
+supported.
+
 
 ### Spark Properties
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -153,9 +153,14 @@ the driver container as a [secret volume](https://kubernetes.io/docs/user-guide/
 ### Kubernetes Clusters and the authenticated proxy endpoint
 
 Spark-submit also supports submission through the
-local kubectl proxy](https://kubernetes.io/docs/user-guide/connecting-to-applications-proxy/). One can use the
+[local kubectl proxy](https://kubernetes.io/docs/user-guide/connecting-to-applications-proxy/). One can use the
 authenticating proxy to communicate with the api server directly without passing credentials to spark-submit.
-For example, if our local proxy were listening on port 8001, we would have our submission looking like the following:
+
+The local proxy can be started by running:
+
+    kubectl proxy
+
+If our local proxy were listening on port 8001, we would have our submission looking like the following:
 
     bin/spark-submit \
       --deploy-mode cluster \
@@ -168,9 +173,10 @@ For example, if our local proxy were listening on port 8001, we would have our s
       --conf spark.kubernetes.executor.docker.image=registry-host:5000/spark-executor:latest \
       examples/jars/spark_examples_2.11-2.2.0.jar
 
-This mechanism can also be useful when we have authentication schemes that the client library does not support
-completely.
-
+Communication between Spark and Kubernetes clusters is performed using the fabric8 kubernetes-client library.
+The above mechanism using `kubectl proxy` can be used when we have authentication providers that the fabric8
+kubernetes-client library does not support. Authentication using X509 Client Certs and oauth tokens
+is currently supported.
 
 ### Spark Properties
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -169,8 +169,7 @@ For example, if our local proxy were listening on port 8001, we would have our s
       examples/jars/spark_examples_2.11-2.2.0.jar
 
 This mechanism can also be useful when we have authentication schemes that the client library does not support
-completely. The default authentication schemes, using X509 Client Certs and oauth tokens (gce), are currently
-supported.
+completely.
 
 
 ### Spark Properties

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Kubernetes</name>
   <properties>
     <sbt.project.name>kubernetes</sbt.project.name>
-    <kubernetes.client.version>1.4.34</kubernetes.client.version>
+    <kubernetes.client.version>2.0.3</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -44,7 +44,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   private val EXECUTOR_MODIFICATION_LOCK = new Object
   private val runningExecutorPods = new scala.collection.mutable.HashMap[String, Pod]
 
-  private val kubernetesMaster = Client.resolveK8sMaster(sc.master)
+  private val kubernetesMaster = "https://kubernetes"
   private val executorDockerImage = conf.get(EXECUTOR_DOCKER_IMAGE)
   private val kubernetesNamespace = conf.get(KUBERNETES_NAMESPACE)
   private val executorPort = conf.getInt("spark.executor.port", DEFAULT_STATIC_PORT)


### PR DESCRIPTION
Fixes https://github.com/apache-spark-on-k8s/spark/issues/63

Notable changes:
* Fix to https://github.com/fabric8io/kubernetes-client/issues/636
* Switch to using HTTP Get if websocket connection fails (https://github.com/fabric8io/kubernetes-client/pull/652, https://github.com/fabric8io/kubernetes-client/pull/655, https://github.com/fabric8io/kubernetes-client/pull/656) 
* Using the `https://kubernetes` service as master URL from within the pod, rather than the external IP. ([doc](https://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod))