### PR TITLE
Shutdown the thread scheduler in LoggingPodStatusWatcher on receiving…

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
@@ -64,6 +64,7 @@ private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: CountDownL
 
     if (phase == "Succeeded" || phase == "Failed") {
       podCompletedFuture.countDown()
+      scheduler.shutdown()
     }
   }
 


### PR DESCRIPTION
Fixes #120 

## What changes were proposed in this pull request?
The scheduler inside LoggingPodStatusWatcher doesn't seem to be shutdown after the receiving job finished events. So, I shutdown the scheduler on receiving these events.

## How was this patch tested?
Tested manually that job launcher client exits when the spark job succeeds.
```
017-02-15 13:18:19 INFO  LoggingPodStatusWatcher:54 - Application status for spark-pi-1487193446018 (phase: Running)
2017-02-15 13:18:20 INFO  LoggingPodStatusWatcher:54 - Application status for spark-pi-1487193446018 (phase: Running)
2017-02-15 13:18:21 INFO  LoggingPodStatusWatcher:54 - Application status for spark-pi-1487193446018 (phase: Succeeded)
2017-02-15 13:18:21 INFO  LoggingPodStatusWatcher:54 - Phase changed, new state:
	 pod name: spark-pi-1487193446018
	 namespace: default
	 labels: spark-app-id -> spark-pi-1487193446018, spark-app-name -> spark-pi, spark-driver -> spark-pi-1487193446018
	 pod uid: 28b36eeb-f3c4-11e6-80cf-02f2c310e88c
	 creation time: 2017-02-15T21:17:30Z
	 service account name: default
	 volumes: spark-submission-secret-volume, default-token-7eejh
	 node name: kube-n2.pepperdata.com
	 start time: 2017-02-15T21:17:30Z
	 container images: docker:5000/spark-driver:varun_2_14
	 phase: Succeeded
2017-02-15 13:18:21 INFO  Client:54 - Application spark-pi-1487193446018 finished.
2017-02-15 13:18:21 INFO  WatchConnectionManager:296 - WebSocket close received. code: 1000, reason:
2017-02-15 13:18:21 WARN  WatchConnectionManager:298 - Ignoring onClose for already closed/closing websocket
```
