### PR TITLE
Optionally expose the driver UI port as NodePort

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -194,6 +194,14 @@ from the other deployment modes. See the [configuration page](configuration.html
     Time to wait for the driver pod to start running before aborting its execution.
   </td>
 </tr>
+<tr>
+  <td><code>spark.kubernetes.driver.service.exposeUiPort</code></td>
+  <td><code>false</code></td>
+  <td>
+    Whether to expose the driver Web UI port as a service NodePort. Turned off by default because NodePort is a limited
+    resource. Use alternatives such as Ingress if possible.
+  </td>
+</tr>
 </table>
 
 ## Current Limitations

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -226,13 +226,15 @@ private[spark] class Client(
     logInfo("Successfully submitted local resources and driver configuration to" +
       " driver pod.")
     // After submitting, adjust the service to only expose the Spark UI
+    val serviceType = if (sparkConf.get(EXPOSE_KUBERNETES_DRIVER_SERVICE_UI_PORT)) "NodePort"
+      else "ClusterIP"
     val uiServicePort = new ServicePortBuilder()
       .withName(UI_PORT_NAME)
       .withPort(uiPort)
       .withNewTargetPort(uiPort)
       .build()
     kubernetesClient.services().withName(kubernetesAppId).edit().editSpec()
-      .withType("ClusterIP")
+      .withType(serviceType)
       .withPorts(uiServicePort)
       .endSpec()
       .done()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/Client.scala
@@ -226,7 +226,7 @@ private[spark] class Client(
     logInfo("Successfully submitted local resources and driver configuration to" +
       " driver pod.")
     // After submitting, adjust the service to only expose the Spark UI
-    val serviceType = if (sparkConf.get(EXPOSE_KUBERNETES_DRIVER_SERVICE_UI_PORT)) "NodePort"
+    val uiServiceType = if (sparkConf.get(EXPOSE_KUBERNETES_DRIVER_SERVICE_UI_PORT)) "NodePort"
       else "ClusterIP"
     val uiServicePort = new ServicePortBuilder()
       .withName(UI_PORT_NAME)
@@ -234,7 +234,7 @@ private[spark] class Client(
       .withNewTargetPort(uiPort)
       .build()
     kubernetesClient.services().withName(kubernetesAppId).edit().editSpec()
-      .withType(serviceType)
+      .withType(uiServiceType)
       .withPorts(uiServicePort)
       .endSpec()
       .done()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
@@ -156,6 +156,15 @@ package object config {
         .stringConf
         .createOptional
 
+  private[spark] val EXPOSE_KUBERNETES_DRIVER_SERVICE_UI_PORT =
+    ConfigBuilder("spark.kubernetes.driver.service.exposeUiPort")
+      .doc("""
+          | Whether to expose the driver Web UI port as a service NodePort. Turned off by default
+          | because NodePort is a limited resource. Use alternatives such as Ingress if possible.
+        """.stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val KUBERNETES_DRIVER_POD_NAME =
     ConfigBuilder("spark.kubernetes.driver.pod.name")
       .doc("""


### PR DESCRIPTION
## What changes were proposed in this pull request?

Addresses #129 by optionally exposing the driver Web UI as NodePort.

## How was this patch tested?

Tested again my k8s cluster. I was able to look at the Web UI using my browser.

Ran the integration test successfully:
```
[INFO] Spark Project Kubernetes Integration Tests ......... SUCCESS [15:47 min]
```