### PR TITLE
Update client version & minikube version

### DIFF
--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Kubernetes</name>
   <properties>
     <sbt.project.name>kubernetes</sbt.project.name>
-    <kubernetes.client.version>2.0.3</kubernetes.client.version>
+    <kubernetes.client.version>2.0.7</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -29,7 +29,7 @@
   <name>Spark Project Kubernetes</name>
   <properties>
     <sbt.project.name>kubernetes</sbt.project.name>
-    <kubernetes.client.version>2.0.7</kubernetes.client.version>
+    <kubernetes.client.version>2.2.1</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -247,7 +247,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://storage.googleapis.com/minikube/releases/v0.12.2/minikube-linux-amd64</url>
+              <url>https://storage.googleapis.com/minikube/releases/v0.16.0/minikube-linux-amd64</url>
               <outputDirectory>${project.build.directory}/minikube-bin/linux-amd64</outputDirectory>
               <outputFileName>minikube</outputFileName>
             </configuration>
@@ -259,7 +259,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://storage.googleapis.com/minikube/releases/v0.12.2/minikube-darwin-amd64</url>
+              <url>https://storage.googleapis.com/minikube/releases/v0.16.0/minikube-darwin-amd64</url>
               <outputDirectory>${project.build.directory}/minikube-bin/darwin-amd64</outputDirectory>
               <outputFileName>minikube</outputFileName>
             </configuration>


### PR DESCRIPTION
Bumping up minikube version (0.12.x -> 0.16.0): Fixes https://github.com/apache-spark-on-k8s/spark/issues/98 
Bumping up kubenetes-client version (2.0.3 -> 2.2.1) Fix for the logging issue in https://github.com/apache-spark-on-k8s/spark/issues/120

Other seemingly relevant changes on the fabric8 client side:
* okhttp client upgrade from 3.4.1 to 3.6.0
* improvements to watcher code (https://github.com/fabric8io/kubernetes-client/pull/671)
* Fixes bug in watcher.onClose() not being called.

Tests:
locally passes integration tests

cc @ash211 @mccheah 
