### PR TITLE
Shutdown log watcher explicitly when launcher completes

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/LoggingPodStatusWatcher.scala
@@ -90,6 +90,10 @@ private[kubernetes] class LoggingPodStatusWatcher(podCompletedFuture: CountDownL
 
   private def closeWatch(): Unit = {
     podCompletedFuture.countDown()
+    shutdown()
+  }
+
+  def shutdown(): Unit = {
     scheduler.shutdown()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Addresses potentially remaining problems of #143 by explicitly shutting down the log watcher when the launcher completes. The main problem of #143 is fixed by #154, but the symptom may reappear if we fail to detect DELETED events due to upstream k8s client bugs. I think this patch will help in such a case.

cc @ash211 @foxish 

## How was this patch tested?

Ran integration test. Ran manual tests against the case of #143 before #154 is merged in. 