### PR TITLE
Spark shell [WIP]

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -345,8 +345,12 @@ object SparkSubmit {
           "applications on standalone clusters.")
       case (LOCAL, CLUSTER) =>
         printErrorAndExit("Cluster deploy mode is not compatible with master \"local\"")
-      case (_, CLUSTER) if isShell(args.primaryResource) =>
-        printErrorAndExit("Cluster deploy mode is not applicable to Spark shells.")
+      case (MESOS, CLUSTER) if isShell(args.primaryResource) =>
+        printErrorAndExit("MESOS Cluster deploy mode is not applicable to Spark shells.")
+      case (YARN, CLUSTER) if isShell(args.primaryResource) =>
+        printErrorAndExit("YARN Cluster deploy mode is not applicable to Spark shells.")
+      case (STANDALONE, CLUSTER) if isShell(args.primaryResource) =>
+        printErrorAndExit("Standalone Cluster deploy mode is not applicable to Spark shells.")
       case (_, CLUSTER) if isSqlShell(args.mainClass) =>
         printErrorAndExit("Cluster deploy mode is not applicable to Spark SQL shell.")
       case (_, CLUSTER) if isThriftServer(args.mainClass) =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/KubernetesRestProtocolMessages.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/KubernetesRestProtocolMessages.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.deploy.rest
 
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
-
 import org.apache.spark.SPARK_VERSION
 
 case class KubernetesCredentials(
@@ -53,7 +53,8 @@ case class TarGzippedData(
 @JsonSubTypes(value = Array(
   new JsonSubTypes.Type(value = classOf[UploadedAppResource], name = "UploadedAppResource"),
   new JsonSubTypes.Type(value = classOf[ContainerAppResource], name = "ContainerLocalAppResource"),
-  new JsonSubTypes.Type(value = classOf[RemoteAppResource], name = "RemoteAppResource")))
+  new JsonSubTypes.Type(value = classOf[RemoteAppResource], name = "RemoteAppResource"),
+  new JsonSubTypes.Type(value = classOf[NopAppResource], name = "NopAppResource")))
 abstract class AppResource
 
 case class UploadedAppResource(
@@ -63,6 +64,8 @@ case class UploadedAppResource(
 case class ContainerAppResource(resourcePath: String) extends AppResource
 
 case class RemoteAppResource(resource: String) extends AppResource
+
+case class NopAppResource() extends AppResource
 
 class PingResponse extends SubmitRestProtocolResponse {
   val text = "pong"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/KubernetesSparkRestServer.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/KubernetesSparkRestServer.scala
@@ -378,6 +378,8 @@ private[spark] class KubernetesSparkRestServer(
               s" does not exist at $downloadedFilePath")
           }
           ResolvedAppResource(downloadedFilePath, resource)
+        case NopAppResource() =>
+          ResolvedAppResource("", "")
       }
     }
   }


### PR DESCRIPTION
With these changes, Spark shell "almost" works.

```
./bin/spark-submit --master=k8s://<apiserver-ip:port> --deploy-mode=cluster --class=org.apache.spark.repl.Main \
--conf spark.kubernetes.driver.docker.image=foxish/spark-driver:vtry11 \
--conf spark.kubernetes.executor.docker.image=kubespark/spark-executor:v2.1.0-kubernetes-0.1.0-rc1 \
--conf spark.driver.extraJavaOptions="-Dscala.usejavacp=true"
```

A `kubectl attach` to the driver pod shows:

```
2017-04-01 01:53:31 WARN  NativeCodeLoader:62 - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Spark context Web UI available at http://10.0.0.111:4040
Spark context available as 'sc' (master = k8s://https://35.184.141.248, app id = org-apache-spark-repl-main-1491011566260).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.1.0-k8s-0.1.0-SNAPSHOT
      /_/
         
Using Scala version 2.11.8 (OpenJDK 64-Bit Server VM, Java 1.8.0_121)
Type in expressions to have them evaluated.
Type :help for more information.

scala> :quit
2017-04-01 01:53:49 INFO  KubernetesSparkRestServer$KubernetesSubmitRequestServlet:54 - Spark application complete. Shutting down submission server...
2017-04-01 01:53:49 INFO  ServerConnector:306 - Stopped ServerConnector@4f905baf{HTTP/1.1}{org-apache-spark-repl-main-1491011566260:7077}
```

I think a separate process actually forks off for spark-shell which is why the rest submission driver immediately stops and marks the driver as succeeded. To detect when the driver can stop running, we probably need to watch for subprocesses to exit as well.