### PR TITLE
Download remotely-located resources on driver startup.

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
@@ -365,7 +365,7 @@ package object config extends Logging {
         " resource staging server to download jars.")
       .internal()
       .stringConf
-      .createWithDefault(INIT_CONTAINER_DOWNLOAD_JARS_SECRET_PATH)
+      .createWithDefault(INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_JARS_SECRET_PATH)
 
   private[spark] val INIT_CONTAINER_DOWNLOAD_FILES_RESOURCE_IDENTIFIER =
     ConfigBuilder("spark.kubernetes.driver.initcontainer.downloadFilesResourceIdentifier")
@@ -380,7 +380,23 @@ package object config extends Logging {
         " resource staging server to download files.")
       .internal()
       .stringConf
-      .createWithDefault(INIT_CONTAINER_DOWNLOAD_FILES_SECRET_PATH)
+      .createWithDefault(INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_FILES_SECRET_PATH)
+
+  private[spark] val INIT_CONTAINER_REMOTE_JARS =
+    ConfigBuilder("spark.kubernetes.driver.initcontainer.remoteJars")
+      .doc("Comma-separated list of jar URIs to download in the init-container. This is inferred" +
+        " from spark.jars.")
+      .internal()
+      .stringConf
+      .createOptional
+
+  private[spark] val INIT_CONTAINER_REMOTE_FILES =
+    ConfigBuilder("spark.kubernetes.driver.initcontainer.remoteFiles")
+      .doc("Comma-separated list of file URIs to download in the init-container. This is inferred" +
+        " from spark.files.")
+      .internal()
+      .stringConf
+      .createOptional
 
   private[spark] val INIT_CONTAINER_DOCKER_IMAGE =
     ConfigBuilder("spark.kubernetes.driver.initcontainer.docker.image")
@@ -388,21 +404,37 @@ package object config extends Logging {
       .stringConf
       .createWithDefault(s"spark-driver-init:$sparkVersion")
 
-  private[spark] val DRIVER_LOCAL_JARS_DOWNLOAD_LOCATION =
-    ConfigBuilder("spark.kubernetes.driver.mountdependencies.jarsDownloadDir")
+  private[spark] val DRIVER_SUBMITTED_JARS_DOWNLOAD_LOCATION =
+    ConfigBuilder("spark.kubernetes.driver.mountdependencies.submittedJars.downloadDir")
       .doc("Location to download local jars to in the driver. When using spark-submit, this" +
         " directory must be empty and will be mounted as an empty directory volume on the" +
         " driver pod.")
       .stringConf
       .createWithDefault("/var/spark-data/spark-local-jars")
 
-  private[spark] val DRIVER_LOCAL_FILES_DOWNLOAD_LOCATION =
-    ConfigBuilder("spark.kubernetes.driver.mountdependencies.filesDownloadDir")
+  private[spark] val DRIVER_SUBMITTED_FILES_DOWNLOAD_LOCATION =
+    ConfigBuilder("spark.kubernetes.driver.mountdependencies.submittedFiles.downloadDir")
       .doc("Location to download local files to in the driver. When using spark-submit, this" +
         " directory must be empty and will be mounted as an empty directory volume on the" +
         " driver pod.")
       .stringConf
       .createWithDefault("/var/spark-data/spark-local-files")
+
+  private[spark] val DRIVER_REMOTE_JARS_DOWNLOAD_LOCATION =
+    ConfigBuilder("spark.kubernetes.driver.mountdependencies.remoteJars.downloadDir")
+      .doc("Location to download remotely-located (e.g. HDFS) jars to in the driver. When" +
+        " using spark-submit, this directory must be empty and will be mounted as an empty" +
+        " directory volume on the driver pod.")
+      .stringConf
+      .createWithDefault("/var/spark-data/spark-remote-jars")
+
+  private[spark] val DRIVER_REMOTE_FILES_DOWNLOAD_LOCATION =
+    ConfigBuilder("spark.kubernetes.driver.mountdependencies.remoteFiles.downloadDir")
+      .doc("Location to download remotely-located (e.g. HDFS) files to in the driver. When" +
+        " using spark-submit, this directory must be empty and will be mounted as an empty" +
+        " directory volume on the driver pod.")
+      .stringConf
+      .createWithDefault("/var/spark-data/spark-remote-files")
 
   private[spark] val DRIVER_MOUNT_DEPENDENCIES_INIT_TIMEOUT =
     ConfigBuilder("spark.kubernetes.mountdependencies.mountTimeout")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/constants.scala
@@ -70,7 +70,6 @@ package object constants {
   private[spark] val ENV_EXECUTOR_ID = "SPARK_EXECUTOR_ID"
   private[spark] val ENV_EXECUTOR_POD_IP = "SPARK_EXECUTOR_POD_IP"
   private[spark] val ENV_DRIVER_MEMORY = "SPARK_DRIVER_MEMORY"
-  private[spark] val ENV_UPLOADED_JARS_DIR = "SPARK_UPLOADED_JARS_DIR"
   private[spark] val ENV_SUBMIT_EXTRA_CLASSPATH = "SPARK_SUBMIT_EXTRA_CLASSPATH"
   private[spark] val ENV_MOUNTED_CLASSPATH = "SPARK_MOUNTED_CLASSPATH"
   private[spark] val ENV_DRIVER_MAIN_CLASS = "SPARK_DRIVER_CLASS"
@@ -92,25 +91,59 @@ package object constants {
 
   // V2 submission init container
   private[spark] val INIT_CONTAINER_ANNOTATION = "pod.beta.kubernetes.io/init-containers"
-  private[spark] val INIT_CONTAINER_SECRETS_VOLUME_NAME = "dependency-secret"
-  private[spark] val INIT_CONTAINER_SECRETS_VOLUME_MOUNT_PATH = "/mnt/secrets/spark-init"
-  private[spark] val INIT_CONTAINER_DOWNLOAD_JARS_SECRET_KEY = "downloadJarsSecret"
-  private[spark] val INIT_CONTAINER_DOWNLOAD_FILES_SECRET_KEY = "downloadFilesSecret"
-  private[spark] val INIT_CONTAINER_TRUSTSTORE_SECRET_KEY = "trustStore"
-  private[spark] val INIT_CONTAINER_DOWNLOAD_JARS_SECRET_PATH =
-    s"$INIT_CONTAINER_SECRETS_VOLUME_MOUNT_PATH/$INIT_CONTAINER_DOWNLOAD_JARS_SECRET_KEY"
-  private[spark] val INIT_CONTAINER_DOWNLOAD_FILES_SECRET_PATH =
-    s"$INIT_CONTAINER_SECRETS_VOLUME_MOUNT_PATH/$INIT_CONTAINER_DOWNLOAD_FILES_SECRET_KEY"
-  private[spark] val INIT_CONTAINER_TRUSTSTORE_PATH =
-    s"$INIT_CONTAINER_SECRETS_VOLUME_MOUNT_PATH/$INIT_CONTAINER_TRUSTSTORE_SECRET_KEY"
-  private[spark] val INIT_CONTAINER_DOWNLOAD_CREDENTIALS_PATH =
-    "/mnt/secrets/kubernetes-credentials"
-  private[spark] val INIT_CONTAINER_CONFIG_MAP_KEY = "init-driver"
-  private[spark] val INIT_CONTAINER_PROPERTIES_FILE_VOLUME = "init-container-properties"
-  private[spark] val INIT_CONTAINER_PROPERTIES_FILE_MOUNT_PATH = "/etc/spark-init/"
-  private[spark] val INIT_CONTAINER_PROPERTIES_FILE_NAME = "init-driver.properties"
-  private[spark] val INIT_CONTAINER_PROPERTIES_FILE_PATH =
-    s"$INIT_CONTAINER_PROPERTIES_FILE_MOUNT_PATH/$INIT_CONTAINER_PROPERTIES_FILE_NAME"
-  private[spark] val DOWNLOAD_JARS_VOLUME_NAME = "download-jars"
-  private[spark] val DOWNLOAD_FILES_VOLUME_NAME = "download-files"
+
+  // Init container for downloading submitted files from the staging server.
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_CONTAINER_NAME =
+    "spark-driver-download-submitted-files"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_SECRETS_VOLUME_NAME =
+    "resource-staging-server-secret"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_SECRETS_VOLUME_MOUNT_PATH =
+    "/mnt/secrets/spark-init"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_JARS_SECRET_KEY =
+    "downloadSubmittedJarsSecret"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_FILES_SECRET_KEY =
+    "downloadSubmittedFilesSecret"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_TRUSTSTORE_SECRET_KEY = "trustStore"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_JARS_SECRET_PATH =
+    s"$INIT_CONTAINER_SUBMITTED_FILES_SECRETS_VOLUME_MOUNT_PATH/" +
+      s"$INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_JARS_SECRET_KEY"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_FILES_SECRET_PATH =
+    s"$INIT_CONTAINER_SUBMITTED_FILES_SECRETS_VOLUME_MOUNT_PATH/" +
+      s"$INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_FILES_SECRET_KEY"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_TRUSTSTORE_PATH =
+    s"$INIT_CONTAINER_SUBMITTED_FILES_SECRETS_VOLUME_MOUNT_PATH/" +
+      s"$INIT_CONTAINER_SUBMITTED_FILES_TRUSTSTORE_SECRET_KEY"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_CONFIG_MAP_KEY =
+    "download-submitted-files"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_PROPERTIES_FILE_VOLUME =
+    "download-submitted-files-properties"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_PROPERTIES_FILE_MOUNT_PATH =
+    "/etc/spark-init/download-submitted-files"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_PROPERTIES_FILE_NAME =
+    "init-driver-download-submitted-files.properties"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_PROPERTIES_FILE_PATH =
+    s"$INIT_CONTAINER_SUBMITTED_FILES_PROPERTIES_FILE_MOUNT_PATH/" +
+      s"$INIT_CONTAINER_SUBMITTED_FILES_PROPERTIES_FILE_NAME"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_JARS_VOLUME_NAME =
+    "download-submitted-jars"
+  private[spark] val INIT_CONTAINER_SUBMITTED_FILES_DOWNLOAD_FILES_VOLUME_NAME =
+    "download-submitted-files"
+
+  // Init container for fetching remote dependencies.
+  private[spark] val INIT_CONTAINER_REMOTE_FILES_CONTAINER_NAME =
+    "spark-driver-download-remote-files"
+  private[spark] val INIT_CONTAINER_REMOTE_FILES_CONFIG_MAP_KEY =
+    "download-remote-files"
+  private[spark] val INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_VOLUME =
+    "download-remote-files-properties"
+  private[spark] val INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_MOUNT_PATH =
+    "/etc/spark-init/download-remote-files"
+  private[spark] val INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_NAME =
+    "init-driver-download-remote-files.properties"
+  private[spark] val INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_PATH =
+    s"$INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_MOUNT_PATH/" +
+      s"$INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_NAME"
+  private[spark] val INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_JARS_VOLUME_NAME = "download-remote-jars"
+  private[spark] val INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_FILES_VOLUME_NAME =
+    "download-remote-files"
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/KubernetesFileUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/KubernetesFileUtils.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.deploy.rest.kubernetes.v1
+package org.apache.spark.deploy.kubernetes.submit
 
 import org.apache.spark.util.Utils
 
@@ -39,6 +39,10 @@ private[spark] object KubernetesFileUtils {
 
   def isUriLocalFile(uri: String): Boolean = {
     Option(Utils.resolveURI(uri).getScheme).getOrElse("file") == "file"
+  }
+
+  def getOnlyRemoteFiles(uris: Iterable[String]): Iterable[String] = {
+    filterUriStringsByScheme(uris, scheme => scheme != "file" && scheme != "local")
   }
 
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v1/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v1/Client.scala
@@ -33,7 +33,8 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.deploy.kubernetes.CompressionUtils
 import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.deploy.kubernetes.constants._
-import org.apache.spark.deploy.rest.kubernetes.v1.{AppResource, ContainerAppResource, HttpClientUtil, KubernetesCreateSubmissionRequest, KubernetesCredentials, KubernetesFileUtils, KubernetesSparkRestApi, RemoteAppResource, UploadedAppResource}
+import org.apache.spark.deploy.kubernetes.submit.KubernetesFileUtils
+import org.apache.spark.deploy.rest.kubernetes.v1.{AppResource, ContainerAppResource, HttpClientUtil, KubernetesCreateSubmissionRequest, KubernetesCredentials, KubernetesSparkRestApi, RemoteAppResource, UploadedAppResource}
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.{ShutdownHookManager, Utils}
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v1/DriverSubmitSslConfigurationProvider.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v1/DriverSubmitSslConfigurationProvider.scala
@@ -29,7 +29,8 @@ import scala.collection.JavaConverters._
 import org.apache.spark.{SecurityManager => SparkSecurityManager, SparkConf, SparkException, SSLOptions}
 import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.deploy.kubernetes.constants._
-import org.apache.spark.deploy.rest.kubernetes.v1.{KubernetesFileUtils, PemsToKeyStoreConverter}
+import org.apache.spark.deploy.kubernetes.submit.KubernetesFileUtils
+import org.apache.spark.deploy.rest.kubernetes.v1.PemsToKeyStoreConverter
 import org.apache.spark.util.Utils
 
 /**

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/DownloadRemoteDependencyManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/DownloadRemoteDependencyManager.scala
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.submit.v2
+
+import java.io.File
+
+import io.fabric8.kubernetes.api.model.{ConfigMap, ContainerBuilder, EmptyDirVolumeSource, PodBuilder, VolumeMountBuilder}
+
+import org.apache.spark.deploy.kubernetes.config._
+import org.apache.spark.deploy.kubernetes.constants._
+import org.apache.spark.deploy.kubernetes.submit.KubernetesFileUtils
+import org.apache.spark.util.Utils
+
+private[spark] trait DownloadRemoteDependencyManager {
+
+  def buildInitContainerConfigMap(): ConfigMap
+
+  def configurePodToDownloadRemoteDependencies(
+    initContainerConfigMap: ConfigMap,
+    driverContainerName: String,
+    originalPodSpec: PodBuilder): PodBuilder
+
+  /**
+   * Return the local classpath of the driver after all of its dependencies have been downloaded.
+   */
+  def resolveLocalClasspath(): Seq[String]
+}
+
+// TODO this is very similar to SubmittedDependencyManagerImpl. We should consider finding a way to
+// consolidate the implementations.
+private[spark] class DownloadRemoteDependencyManagerImpl(
+    kubernetesAppId: String,
+    sparkJars: Seq[String],
+    sparkFiles: Seq[String],
+    jarsDownloadPath: String,
+    filesDownloadPath: String,
+    initContainerImage: String) extends DownloadRemoteDependencyManager {
+
+  private val jarsToDownload = KubernetesFileUtils.getOnlyRemoteFiles(sparkJars)
+  private val filesToDownload = KubernetesFileUtils.getOnlyRemoteFiles(sparkFiles)
+
+  override def buildInitContainerConfigMap(): ConfigMap = {
+    val remoteJarsConf = if (jarsToDownload.nonEmpty) {
+      Map(INIT_CONTAINER_REMOTE_JARS.key -> jarsToDownload.mkString(","))
+    } else {
+      Map.empty[String, String]
+    }
+    val remoteFilesConf = if (filesToDownload.nonEmpty) {
+      Map(INIT_CONTAINER_REMOTE_FILES.key -> filesToDownload.mkString(","))
+    } else {
+      Map.empty[String, String]
+    }
+    val initContainerConfig = Map[String, String](
+      DRIVER_REMOTE_JARS_DOWNLOAD_LOCATION.key -> jarsDownloadPath,
+      DRIVER_REMOTE_FILES_DOWNLOAD_LOCATION.key -> filesDownloadPath) ++
+      remoteJarsConf ++
+      remoteFilesConf
+    PropertiesConfigMapFromScalaMapBuilder.buildConfigMap(
+      s"$kubernetesAppId-remote-files-download-init",
+      INIT_CONTAINER_REMOTE_FILES_CONFIG_MAP_KEY,
+      initContainerConfig)
+  }
+
+  override def configurePodToDownloadRemoteDependencies(
+      initContainerConfigMap: ConfigMap,
+      driverContainerName: String,
+      originalPodSpec: PodBuilder): PodBuilder = {
+    val sharedVolumeMounts = Seq(
+      new VolumeMountBuilder()
+        .withName(INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_JARS_VOLUME_NAME)
+        .withMountPath(jarsDownloadPath)
+        .build(),
+      new VolumeMountBuilder()
+        .withName(INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_FILES_VOLUME_NAME)
+        .withMountPath(filesDownloadPath)
+        .build())
+    val initContainer = new ContainerBuilder()
+      .withName(INIT_CONTAINER_REMOTE_FILES_CONTAINER_NAME)
+      .withArgs(INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_PATH)
+      .addNewVolumeMount()
+        .withName(INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_VOLUME)
+        .withMountPath(INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_MOUNT_PATH)
+        .endVolumeMount()
+      .addToVolumeMounts(sharedVolumeMounts: _*)
+      .withImage(initContainerImage)
+      .withImagePullPolicy("IfNotPresent")
+      .build()
+    InitContainerUtil.appendInitContainer(originalPodSpec, initContainer)
+      .editSpec()
+        .addNewVolume()
+          .withName(INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_VOLUME)
+          .withNewConfigMap()
+            .withName(initContainerConfigMap.getMetadata.getName)
+            .addNewItem()
+              .withKey(INIT_CONTAINER_REMOTE_FILES_CONFIG_MAP_KEY)
+              .withPath(INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_NAME)
+              .endItem()
+            .endConfigMap()
+          .endVolume()
+        .addNewVolume()
+          .withName(INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_JARS_VOLUME_NAME)
+          .withEmptyDir(new EmptyDirVolumeSource())
+          .endVolume()
+        .addNewVolume()
+          .withName(INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_FILES_VOLUME_NAME)
+          .withEmptyDir(new EmptyDirVolumeSource())
+          .endVolume()
+        .editMatchingContainer(new ContainerNameEqualityPredicate(driverContainerName))
+          .addToVolumeMounts(sharedVolumeMounts: _*)
+          .endContainer()
+        .endSpec()
+  }
+
+  override def resolveLocalClasspath(): Seq[String] = {
+    sparkJars.map { jar =>
+      val jarUri = Utils.resolveURI(jar)
+      val scheme = Option.apply(jarUri.getScheme).getOrElse("file")
+      scheme match {
+        case "file" | "local" => jarUri.getPath
+        case _ =>
+          val fileName = new File(jarUri.getPath).getName
+          s"$jarsDownloadPath/$fileName"
+      }
+    }
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/DownloadRemoteDependencyManagerProvider.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/DownloadRemoteDependencyManagerProvider.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.submit.v2
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.kubernetes.config._
+
+private[spark] trait DownloadRemoteDependencyManagerProvider {
+  def getDownloadRemoteDependencyManager(
+      kubernetesAppId: String,
+      sparkJars: Seq[String],
+      sparkFiles: Seq[String]): DownloadRemoteDependencyManager
+}
+
+private[spark] class DownloadRemoteDependencyManagerProviderImpl(
+    sparkConf: SparkConf) extends DownloadRemoteDependencyManagerProvider {
+
+  override def getDownloadRemoteDependencyManager(
+      kubernetesAppId: String,
+      sparkJars: Seq[String],
+      sparkFiles: Seq[String]): DownloadRemoteDependencyManager = {
+    new DownloadRemoteDependencyManagerImpl(
+      kubernetesAppId,
+      sparkJars,
+      sparkFiles,
+      sparkConf.get(DRIVER_REMOTE_JARS_DOWNLOAD_LOCATION),
+      sparkConf.get(DRIVER_REMOTE_FILES_DOWNLOAD_LOCATION),
+      sparkConf.get(INIT_CONTAINER_DOCKER_IMAGE))
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/InitContainerUtil.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/InitContainerUtil.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.submit.v2
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import io.fabric8.kubernetes.api.model.{Container, PodBuilder}
+import scala.collection.JavaConverters._
+
+import org.apache.spark.deploy.kubernetes.constants._
+
+private[spark] object InitContainerUtil {
+
+  private val OBJECT_MAPPER = new ObjectMapper().registerModule(new DefaultScalaModule)
+
+  def appendInitContainer(
+    originalPodSpec: PodBuilder, initContainer: Container): PodBuilder = {
+    val resolvedInitContainers = originalPodSpec
+      .editMetadata()
+      .getAnnotations
+      .asScala
+      .get(INIT_CONTAINER_ANNOTATION)
+      .map { existingInitContainerAnnotation =>
+        val existingInitContainers = OBJECT_MAPPER.readValue(
+          existingInitContainerAnnotation, classOf[List[Container]])
+        existingInitContainers ++ Seq(initContainer)
+      }.getOrElse(Seq(initContainer))
+    val resolvedSerializedInitContainers = OBJECT_MAPPER.writeValueAsString(resolvedInitContainers)
+    originalPodSpec
+      .editMetadata()
+      .removeFromAnnotations(INIT_CONTAINER_ANNOTATION)
+      .addToAnnotations(INIT_CONTAINER_ANNOTATION, resolvedSerializedInitContainers)
+      .endMetadata()
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/PropertiesConfigMapFromScalaMapBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/PropertiesConfigMapFromScalaMapBuilder.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.kubernetes.submit.v2
+
+import java.io.StringWriter
+import java.util.Properties
+
+import io.fabric8.kubernetes.api.model.{ConfigMap, ConfigMapBuilder}
+
+/**
+ * Creates a config map from a map object, with a single given key
+ * and writing the map in a {@link java.util.Properties} format.
+ */
+private[spark] object PropertiesConfigMapFromScalaMapBuilder {
+
+  def buildConfigMap(
+      configMapName: String,
+      configMapKey: String,
+      config: Map[String, String]): ConfigMap = {
+    val properties = new Properties()
+    config.foreach { case (key, value) => properties.setProperty(key, value) }
+    val propertiesWriter = new StringWriter()
+    properties.store(propertiesWriter,
+      s"Java properties built from Kubernetes config map with name: $configMapName" +
+        " and config map key: $configMapKey")
+    new ConfigMapBuilder()
+      .withNewMetadata()
+        .withName(configMapName)
+        .endMetadata()
+      .addToData(configMapKey, propertiesWriter.toString)
+      .build()
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/SubmittedDependencyManagerProvider.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/SubmittedDependencyManagerProvider.scala
@@ -20,35 +20,35 @@ import org.apache.spark.{SecurityManager => SparkSecurityManager, SparkConf}
 import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.deploy.rest.kubernetes.v2.RetrofitClientFactoryImpl
 
-private[spark] trait MountedDependencyManagerProvider {
-  def getMountedDependencyManager(
+private[spark] trait SubmittedDependencyManagerProvider {
+  def getSubmittedDependencyManager(
     kubernetesAppId: String,
     stagingServerUri: String,
     podLabels: Map[String, String],
     podNamespace: String,
     sparkJars: Seq[String],
-    sparkFiles: Seq[String]): MountedDependencyManager
+    sparkFiles: Seq[String]): SubmittedDependencyManager
 }
 
-private[spark] class MountedDependencyManagerProviderImpl(sparkConf: SparkConf)
-    extends MountedDependencyManagerProvider {
-  override def getMountedDependencyManager(
+private[spark] class SubmittedDependencyManagerProviderImpl(sparkConf: SparkConf)
+    extends SubmittedDependencyManagerProvider {
+  override def getSubmittedDependencyManager(
       kubernetesAppId: String,
       stagingServerUri: String,
       podLabels: Map[String, String],
       podNamespace: String,
       sparkJars: Seq[String],
-      sparkFiles: Seq[String]): MountedDependencyManager = {
+      sparkFiles: Seq[String]): SubmittedDependencyManager = {
     val resourceStagingServerSslOptions = new SparkSecurityManager(sparkConf)
       .getSSLOptions("kubernetes.resourceStagingServer")
-    new MountedDependencyManagerImpl(
+    new SubmittedDependencyManagerImpl(
       kubernetesAppId,
       podLabels,
       podNamespace,
       stagingServerUri,
       sparkConf.get(INIT_CONTAINER_DOCKER_IMAGE),
-      sparkConf.get(DRIVER_LOCAL_JARS_DOWNLOAD_LOCATION),
-      sparkConf.get(DRIVER_LOCAL_FILES_DOWNLOAD_LOCATION),
+      sparkConf.get(DRIVER_SUBMITTED_JARS_DOWNLOAD_LOCATION),
+      sparkConf.get(DRIVER_SUBMITTED_FILES_DOWNLOAD_LOCATION),
       sparkConf.get(DRIVER_MOUNT_DEPENDENCIES_INIT_TIMEOUT),
       sparkJars,
       sparkFiles,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/v1/KubernetesSparkRestServer.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/v1/KubernetesSparkRestServer.scala
@@ -35,6 +35,7 @@ import org.apache.spark.{SecurityManager, SPARK_VERSION => sparkVersion, SparkCo
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.kubernetes.CompressionUtils
 import org.apache.spark.deploy.kubernetes.config._
+import org.apache.spark.deploy.kubernetes.submit.KubernetesFileUtils
 import org.apache.spark.deploy.rest._
 import org.apache.spark.internal.config.OptionalConfigEntry
 import org.apache.spark.util.{ShutdownHookManager, ThreadUtils, Utils}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/v2/KubernetesSparkDependencyDownloadInitContainer.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/v2/KubernetesSparkDependencyDownloadInitContainer.scala
@@ -25,12 +25,15 @@ import com.google.common.io.Files
 import com.google.common.util.concurrent.SettableFuture
 import okhttp3.ResponseBody
 import retrofit2.{Call, Callback, Response}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
 
-import org.apache.spark.{SecurityManager => SparkSecurityManager, SparkConf, SparkException}
+import org.apache.spark.{SecurityManager => SparkSecurityManager, SparkConf}
+import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.deploy.kubernetes.CompressionUtils
 import org.apache.spark.internal.Logging
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 private trait WaitableCallback[T] extends Callback[T] {
   private val complete = SettableFuture.create[Boolean]
@@ -61,55 +64,153 @@ private class DownloadTarGzCallback(downloadDir: File) extends WaitableCallback[
   }
 }
 
+// Extracted for testing so that unit tests don't have to depend on Utils.fetchFile
+private[v2] trait FileFetcher {
+  def fetchFile(uri: String, targetDir: File): Unit
+}
+
+private class FileFetcherImpl(sparkConf: SparkConf, securityManager: SparkSecurityManager)
+    extends FileFetcher {
+  def fetchFile(uri: String, targetDir: File): Unit = {
+    Utils.fetchFile(
+      url = uri,
+      targetDir = targetDir,
+      conf = sparkConf,
+      securityMgr = securityManager,
+      hadoopConf = SparkHadoopUtil.get.newConfiguration(sparkConf),
+      timestamp = System.currentTimeMillis(),
+      useCache = false)
+  }
+}
+
+/**
+ * Process that fetches files from a resource staging server and/or arbi trary remote locations.
+ *
+ * The init-container can handle fetching files from any of those sources, but not all of the
+ * sources need to be specified. This allows for composing multiple instances of this container
+ * with different configurations for different download sources, or using the same container to
+ * download everything at once.
+ */
 private[spark] class KubernetesSparkDependencyDownloadInitContainer(
-    sparkConf: SparkConf, retrofitClientFactory: RetrofitClientFactory) extends Logging {
+    sparkConf: SparkConf,
+    retrofitClientFactory: RetrofitClientFactory,
+    fileFetcher: FileFetcher,
+    securityManager: SparkSecurityManager) extends Logging {
 
-  private val resourceStagingServerUri = sparkConf.get(RESOURCE_STAGING_SERVER_URI)
-    .getOrElse(throw new SparkException("No dependency server URI was provided."))
+  private implicit val downloadExecutor = ExecutionContext.fromExecutorService(
+    ThreadUtils.newDaemonCachedThreadPool("download-executor"))
+  private val maybeResourceStagingServerUri = sparkConf.get(RESOURCE_STAGING_SERVER_URI)
 
-  private val downloadJarsResourceIdentifier = sparkConf
+  private val maybeDownloadJarsResourceIdentifier = sparkConf
     .get(INIT_CONTAINER_DOWNLOAD_JARS_RESOURCE_IDENTIFIER)
-    .getOrElse(throw new SparkException("No resource identifier provided for jars."))
   private val downloadJarsSecretLocation = new File(
     sparkConf.get(INIT_CONTAINER_DOWNLOAD_JARS_SECRET_LOCATION))
-  private val downloadFilesResourceIdentifier = sparkConf
+  private val maybeDownloadFilesResourceIdentifier = sparkConf
     .get(INIT_CONTAINER_DOWNLOAD_FILES_RESOURCE_IDENTIFIER)
-    .getOrElse(throw new SparkException("No resource identifier provided for files."))
   private val downloadFilesSecretLocation = new File(
     sparkConf.get(INIT_CONTAINER_DOWNLOAD_FILES_SECRET_LOCATION))
-  require(downloadJarsSecretLocation.isFile, "Application jars download secret provided" +
-    s" at ${downloadJarsSecretLocation.getAbsolutePath} does not exist or is not a file.")
-  require(downloadFilesSecretLocation.isFile, "Application files download secret provided" +
-    s" at ${downloadFilesSecretLocation.getAbsolutePath} does not exist or is not a file.")
 
-  private val jarsDownloadDir = new File(sparkConf.get(DRIVER_LOCAL_JARS_DOWNLOAD_LOCATION))
-  require(jarsDownloadDir.isDirectory, "Application jars download directory provided at" +
-    s" ${jarsDownloadDir.getAbsolutePath} does not exist or is not a directory.")
+  private val stagingServerJarsDownloadDir = new File(
+    sparkConf.get(DRIVER_SUBMITTED_JARS_DOWNLOAD_LOCATION))
+  private val stagingServerFilesDownloadDir = new File(
+    sparkConf.get(DRIVER_SUBMITTED_FILES_DOWNLOAD_LOCATION))
 
-  private val filesDownloadDir = new File(sparkConf.get(DRIVER_LOCAL_FILES_DOWNLOAD_LOCATION))
-  require(filesDownloadDir.isDirectory, "Application files download directory provided at" +
-    s" ${filesDownloadDir.getAbsolutePath} does not exist or is not a directory.")
+  private val remoteJars = sparkConf.get(INIT_CONTAINER_REMOTE_JARS)
+  private val remoteFiles = sparkConf.get(INIT_CONTAINER_REMOTE_FILES)
+  private val remoteJarsDownloadDir = new File(
+    sparkConf.get(DRIVER_REMOTE_JARS_DOWNLOAD_LOCATION))
+  private val remoteFilesDownloadDir = new File(
+    sparkConf.get(DRIVER_REMOTE_FILES_DOWNLOAD_LOCATION))
+
   private val downloadTimeoutMinutes = sparkConf.get(DRIVER_MOUNT_DEPENDENCIES_INIT_TIMEOUT)
 
   def run(): Unit = {
-    val securityManager = new SparkSecurityManager(sparkConf)
-    val sslOptions = securityManager.getSSLOptions("kubernetes.resourceStagingServer")
-    val service = retrofitClientFactory.createRetrofitClient(
-      resourceStagingServerUri, classOf[ResourceStagingServiceRetrofit], sslOptions)
-    val jarsSecret = Files.toString(downloadJarsSecretLocation, Charsets.UTF_8)
-    val filesSecret = Files.toString(downloadFilesSecretLocation, Charsets.UTF_8)
-    val downloadJarsCallback = new DownloadTarGzCallback(jarsDownloadDir)
-    val downloadFilesCallback = new DownloadTarGzCallback(filesDownloadDir)
-    service.downloadResources(downloadJarsResourceIdentifier, jarsSecret)
-      .enqueue(downloadJarsCallback)
-    service.downloadResources(downloadFilesResourceIdentifier, filesSecret)
-      .enqueue(downloadFilesCallback)
-    logInfo("Waiting to download jars...")
-    downloadJarsCallback.waitForCompletion(downloadTimeoutMinutes, TimeUnit.MINUTES)
-    logInfo(s"Jars downloaded to ${jarsDownloadDir.getAbsolutePath}")
-    logInfo("Waiting to download files...")
-    downloadFilesCallback.waitForCompletion(downloadTimeoutMinutes, TimeUnit.MINUTES)
-    logInfo(s"Files downloaded to ${filesDownloadDir.getAbsolutePath}")
+    val resourceStagingServerJarsDownload = Future[Unit] {
+      downloadResourcesFromStagingServer(
+        maybeDownloadJarsResourceIdentifier,
+        downloadJarsSecretLocation,
+        stagingServerJarsDownloadDir,
+        "Starting to download jars from resource staging server...",
+        "Finished downloading jars from resource staging server.",
+        s"Application jars download secret provided at" +
+          s" ${downloadJarsSecretLocation.getAbsolutePath} does not exist or is not a file.",
+        s"Application jars download directory provided at" +
+          s" ${stagingServerJarsDownloadDir.getAbsolutePath} does not exist or is not a directory.")
+    }
+    val resourceStagingServerFilesDownload = Future[Unit] {
+      downloadResourcesFromStagingServer(
+        maybeDownloadFilesResourceIdentifier,
+        downloadFilesSecretLocation,
+        stagingServerFilesDownloadDir,
+        "Starting to download files from resource staging server...",
+        "Finished downloading files from resource staging server.",
+        s"Application files download secret provided at" +
+          s" ${downloadFilesSecretLocation.getAbsolutePath} does not exist or is not a file.",
+        s"Application files download directory provided at" +
+          s" ${stagingServerFilesDownloadDir.getAbsolutePath} does not exist or is not" +
+          s" a directory.")
+    }
+    val remoteJarsDownload = Future[Unit] {
+      downloadFiles(remoteJars,
+        remoteJarsDownloadDir,
+        s"Remote jars download directory specified at $remoteJarsDownloadDir does not exist" +
+          s" or is not a directory.")
+    }
+    val remoteFilesDownload = Future[Unit] {
+      downloadFiles(remoteFiles,
+        remoteFilesDownloadDir,
+        s"Remote files download directory specified at $remoteFilesDownloadDir does not exist" +
+          s" or is not a directory.")
+    }
+    waitForFutures(
+      resourceStagingServerJarsDownload,
+      resourceStagingServerFilesDownload,
+      remoteJarsDownload,
+      remoteFilesDownload)
+  }
+
+  private def downloadResourcesFromStagingServer(
+      maybeResourceId: Option[String],
+      resourceSecretLocation: File,
+      resourceDownloadDir: File,
+      downloadStartMessage: String,
+      downloadFinishedMessage: String,
+      errMessageOnSecretNotAFile: String,
+      errMessageOnDownloadDirNotADirectory: String): Unit = {
+    maybeResourceStagingServerUri.foreach { resourceStagingServerUri =>
+      maybeResourceId.foreach { resourceId =>
+        require(resourceSecretLocation.isFile, errMessageOnSecretNotAFile)
+        require(resourceDownloadDir.isDirectory, errMessageOnDownloadDirNotADirectory)
+        val sslOptions = securityManager.getSSLOptions("kubernetes.resourceStagingServer")
+        val service = retrofitClientFactory.createRetrofitClient(
+          resourceStagingServerUri, classOf[ResourceStagingServiceRetrofit], sslOptions)
+        val resourceSecret = Files.toString(resourceSecretLocation, Charsets.UTF_8)
+        val downloadResourceCallback = new DownloadTarGzCallback(resourceDownloadDir)
+        logInfo(downloadStartMessage)
+        service.downloadResources(resourceId, resourceSecret)
+          .enqueue(downloadResourceCallback)
+        downloadResourceCallback.waitForCompletion(downloadTimeoutMinutes, TimeUnit.MINUTES)
+        logInfo(downloadFinishedMessage)
+      }
+    }
+  }
+
+  private def downloadFiles(
+      filesCommaSeparated: Option[String],
+      downloadDir: File,
+      errMessageOnDestinationNotADirectory: String): Unit = {
+    if (filesCommaSeparated.isDefined) {
+      require(downloadDir.isDirectory, errMessageOnDestinationNotADirectory)
+    }
+    filesCommaSeparated.map(_.split(",")).toSeq.flatten.foreach { file =>
+      fileFetcher.fetchFile(file, downloadDir)
+    }
+  }
+
+  private def waitForFutures(futures: Future[_]*) {
+    futures.foreach {
+      ThreadUtils.awaitResult(_, Duration.create(downloadTimeoutMinutes, TimeUnit.MINUTES))
+    }
   }
 }
 
@@ -121,7 +222,13 @@ object KubernetesSparkDependencyDownloadInitContainer extends Logging {
     } else {
       new SparkConf(true)
     }
-    new KubernetesSparkDependencyDownloadInitContainer(sparkConf, RetrofitClientFactoryImpl).run()
+    val securityManager = new SparkSecurityManager(sparkConf)
+    val fileFetcher = new FileFetcherImpl(sparkConf, securityManager)
+    new KubernetesSparkDependencyDownloadInitContainer(
+      sparkConf,
+      RetrofitClientFactoryImpl,
+      fileFetcher,
+      securityManager).run()
     logInfo("Finished downloading application dependencies.")
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/submit/v2/DownloadRemoteDependencyManagerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/submit/v2/DownloadRemoteDependencyManagerSuite.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.submit.v2
+
+import java.io.StringReader
+import java.util.Properties
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.fabric8.kubernetes.api.model.{ConfigMapBuilder, Container, PodBuilder}
+import scala.collection.JavaConverters._
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.deploy.kubernetes.config._
+import org.apache.spark.deploy.kubernetes.constants._
+
+class DownloadRemoteDependencyManagerSuite extends SparkFunSuite {
+
+  private val OBJECT_MAPPER = new ObjectMapper()
+  private val APP_ID = "app-id"
+  private val SPARK_JARS = Seq(
+    "hdfs://localhost:9000/jar1.jar",
+    "local:///app/jars/jar2.jar",
+    "http://localhost:8080/jar2.jar")
+  private val SPARK_FILES = Seq(
+    "hdfs://localhost:9000/file.txt",
+    "file:///app/files/file.txt")
+  private val JARS_DOWNLOAD_PATH = "/var/data/spark-data/spark-jars"
+  private val FILES_DOWNLOAD_PATH = "/var/data/spark-files/spark-files"
+  private val INIT_CONTAINER_IMAGE = "spark-driver-init:latest"
+  private val dependencyManagerUnderTest = new DownloadRemoteDependencyManagerImpl(
+    APP_ID,
+    SPARK_JARS,
+    SPARK_FILES,
+    JARS_DOWNLOAD_PATH,
+    FILES_DOWNLOAD_PATH,
+    INIT_CONTAINER_IMAGE)
+
+  test("Config map should set the files to download") {
+    val configMap = dependencyManagerUnderTest.buildInitContainerConfigMap()
+    assert(configMap.getMetadata.getName === s"$APP_ID-remote-files-download-init")
+    val configProperties = configMap.getData.asScala
+    assert(configProperties.size === 1)
+    val propertiesString = configProperties(INIT_CONTAINER_REMOTE_FILES_CONFIG_MAP_KEY)
+    assert(propertiesString != null)
+    val propertiesReader = new StringReader(propertiesString)
+    val initContainerProperties = new Properties()
+    initContainerProperties.load(propertiesReader)
+    assert(initContainerProperties.size() === 4)
+    val downloadRemoteJars = initContainerProperties.getProperty(INIT_CONTAINER_REMOTE_JARS.key)
+    assert(downloadRemoteJars != null)
+    val downloadRemoteJarsSplit = downloadRemoteJars.split(",").toSet
+    val expectedRemoteJars = Set(
+      "hdfs://localhost:9000/jar1.jar", "http://localhost:8080/jar2.jar")
+    assert(expectedRemoteJars === downloadRemoteJarsSplit)
+    val downloadRemoteFiles = initContainerProperties.getProperty(INIT_CONTAINER_REMOTE_FILES.key)
+    assert(downloadRemoteFiles != null)
+    val downloadRemoteFilesSplit = downloadRemoteFiles.split(",").toSet
+    val expectedRemoteFiles = Set("hdfs://localhost:9000/file.txt")
+    assert(downloadRemoteFilesSplit === expectedRemoteFiles)
+    assert(initContainerProperties.getProperty(DRIVER_REMOTE_JARS_DOWNLOAD_LOCATION.key) ===
+      JARS_DOWNLOAD_PATH)
+    assert(initContainerProperties.getProperty(DRIVER_REMOTE_FILES_DOWNLOAD_LOCATION.key) ===
+      FILES_DOWNLOAD_PATH)
+  }
+
+  test("Pod should have an appropriate init-container attached") {
+    val originalPodSpec = new PodBuilder()
+      .withNewMetadata()
+        .withName("driver")
+        .endMetadata()
+      .withNewSpec()
+        .addNewContainer()
+          .withName("driver")
+          .endContainer()
+        .endSpec()
+    val configMap = new ConfigMapBuilder()
+      .withNewMetadata()
+        .withName("config-map")
+        .endMetadata()
+      .build()
+    val adjustedPod = dependencyManagerUnderTest.configurePodToDownloadRemoteDependencies(
+      configMap, "driver", originalPodSpec).build()
+    val annotations = adjustedPod.getMetadata.getAnnotations
+    assert(annotations.size === 1)
+    val initContainerAnnotation = annotations.get(INIT_CONTAINER_ANNOTATION)
+    assert(annotations != null)
+    val initContainers = OBJECT_MAPPER.readValue(initContainerAnnotation, classOf[Array[Container]])
+    assert(initContainers.length === 1)
+    val initContainer = initContainers(0)
+    assert(initContainer.getName === INIT_CONTAINER_REMOTE_FILES_CONTAINER_NAME)
+    assert(initContainer.getArgs.size() === 1)
+    assert(initContainer.getArgs.get(0) === INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_PATH)
+    assert(initContainer.getImage === INIT_CONTAINER_IMAGE)
+    assert(initContainer.getImagePullPolicy === "IfNotPresent")
+    val initContainerVolumeMounts = initContainer
+        .getVolumeMounts
+        .asScala
+        .map { mount =>
+      (mount.getName, mount.getMountPath)
+    }.toSet
+    val expectedVolumeMounts = Set(
+      (INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_JARS_VOLUME_NAME, JARS_DOWNLOAD_PATH),
+      (INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_FILES_VOLUME_NAME, FILES_DOWNLOAD_PATH),
+      (INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_VOLUME,
+        INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_MOUNT_PATH))
+    assert(initContainerVolumeMounts === expectedVolumeMounts)
+    val podVolumes = adjustedPod.getSpec.getVolumes.asScala.map { volume =>
+      (volume.getName, volume)
+    }.toMap
+    assert(podVolumes.size === 3)
+    assert(podVolumes.get(INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_VOLUME).isDefined)
+    val propertiesConfigMapVolume = podVolumes(INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_VOLUME)
+    assert(propertiesConfigMapVolume.getConfigMap != null)
+    val configMapItems = propertiesConfigMapVolume.getConfigMap.getItems.asScala
+    assert(configMapItems.size === 1)
+    assert(configMapItems(0).getKey === INIT_CONTAINER_REMOTE_FILES_CONFIG_MAP_KEY)
+    assert(configMapItems(0).getPath === INIT_CONTAINER_REMOTE_FILES_PROPERTIES_FILE_NAME)
+    assert(podVolumes.get(INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_JARS_VOLUME_NAME).isDefined)
+    assert(podVolumes(INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_JARS_VOLUME_NAME).getEmptyDir != null)
+    assert(podVolumes.get(INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_FILES_VOLUME_NAME).isDefined)
+    assert(podVolumes(INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_FILES_VOLUME_NAME).getEmptyDir != null)
+    val addedVolumeMounts = adjustedPod
+      .getSpec
+      .getContainers
+      .get(0)
+      .getVolumeMounts
+      .asScala
+      .map { mount => (mount.getName, mount.getMountPath) }
+      .toSet
+    val expectedAddedVolumeMounts = Set(
+      (INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_JARS_VOLUME_NAME, JARS_DOWNLOAD_PATH),
+      (INIT_CONTAINER_REMOTE_FILES_DOWNLOAD_FILES_VOLUME_NAME, FILES_DOWNLOAD_PATH))
+    assert(addedVolumeMounts === expectedAddedVolumeMounts)
+  }
+
+  test("Resolving the local classpath should map remote jars to their downloaded locations") {
+    val resolvedLocalClasspath = dependencyManagerUnderTest.resolveLocalClasspath()
+    val expectedLocalClasspath = Set(
+      s"$JARS_DOWNLOAD_PATH/jar1.jar",
+      s"$JARS_DOWNLOAD_PATH/jar2.jar",
+      "/app/jars/jar2.jar")
+    assert(resolvedLocalClasspath.toSet === expectedLocalClasspath)
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/KubernetesSparkDependencyDownloadInitContainerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/KubernetesSparkDependencyDownloadInitContainerSuite.scala
@@ -24,6 +24,7 @@ import com.google.common.base.Charsets
 import com.google.common.io.Files
 import okhttp3.{MediaType, ResponseBody}
 import org.mockito.Matchers.any
+import org.mockito.Mockito
 import org.mockito.Mockito.{doAnswer, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -31,7 +32,7 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.mock.MockitoSugar._
 import retrofit2.{Call, Callback, Response}
 
-import org.apache.spark.{SparkConf, SparkFunSuite, SSLOptions}
+import org.apache.spark.{SecurityManager => SparkSecurityManager, SparkConf, SparkFunSuite, SSLOptions}
 import org.apache.spark.deploy.kubernetes.CompressionUtils
 import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.util.Utils
@@ -55,7 +56,6 @@ class KubernetesSparkDependencyDownloadInitContainerSuite
   private val JARS_RESOURCE_ID = "jarsId"
   private val FILES_RESOURCE_ID = "filesId"
 
-  private var sparkConf: SparkConf = _
   private var downloadJarsDir: File = _
   private var downloadFilesDir: File = _
   private var downloadJarsSecretValue: String = _
@@ -64,7 +64,7 @@ class KubernetesSparkDependencyDownloadInitContainerSuite
   private var filesCompressedBytes: Array[Byte] = _
   private var retrofitClientFactory: RetrofitClientFactory = _
   private var retrofitClient: ResourceStagingServiceRetrofit = _
-  private var initContainerUnderTest: KubernetesSparkDependencyDownloadInitContainer = _
+  private var fileFetcher: FileFetcher = _
 
   override def beforeAll(): Unit = {
     jarsCompressedBytes = compressPathsToBytes(JARS)
@@ -80,24 +80,10 @@ class KubernetesSparkDependencyDownloadInitContainerSuite
     downloadFilesDir = Utils.createTempDir()
     retrofitClientFactory = mock[RetrofitClientFactory]
     retrofitClient = mock[ResourceStagingServiceRetrofit]
-    sparkConf = new SparkConf(true)
-      .set(RESOURCE_STAGING_SERVER_URI, STAGING_SERVER_URI)
-      .set(INIT_CONTAINER_DOWNLOAD_JARS_RESOURCE_IDENTIFIER, JARS_RESOURCE_ID)
-      .set(INIT_CONTAINER_DOWNLOAD_JARS_SECRET_LOCATION, DOWNLOAD_JARS_SECRET_LOCATION)
-      .set(INIT_CONTAINER_DOWNLOAD_FILES_RESOURCE_IDENTIFIER, FILES_RESOURCE_ID)
-      .set(INIT_CONTAINER_DOWNLOAD_FILES_SECRET_LOCATION, DOWNLOAD_FILES_SECRET_LOCATION)
-      .set(DRIVER_LOCAL_JARS_DOWNLOAD_LOCATION, downloadJarsDir.getAbsolutePath)
-      .set(DRIVER_LOCAL_FILES_DOWNLOAD_LOCATION, downloadFilesDir.getAbsolutePath)
-      .set(RESOURCE_STAGING_SERVER_SSL_ENABLED, true)
-      .set(RESOURCE_STAGING_SERVER_TRUSTSTORE_FILE, TRUSTSTORE_FILE.getAbsolutePath)
-      .set(RESOURCE_STAGING_SERVER_TRUSTSTORE_PASSWORD, TRUSTSTORE_PASSWORD)
-      .set(RESOURCE_STAGING_SERVER_TRUSTSTORE_TYPE, TRUSTSTORE_TYPE)
-
+    fileFetcher = mock[FileFetcher]
     when(retrofitClientFactory.createRetrofitClient(
         STAGING_SERVER_URI, classOf[ResourceStagingServiceRetrofit], STAGING_SERVER_SSL_OPTIONS))
       .thenReturn(retrofitClient)
-    initContainerUnderTest = new KubernetesSparkDependencyDownloadInitContainer(
-      sparkConf, retrofitClientFactory)
   }
 
   after {
@@ -105,9 +91,15 @@ class KubernetesSparkDependencyDownloadInitContainerSuite
     downloadFilesDir.delete()
   }
 
-  test("Downloads should unpack response body streams to directories") {
+  test("Downloads from resource staging server should unpack response body to directories") {
     val downloadJarsCall = mock[Call[ResponseBody]]
     val downloadFilesCall = mock[Call[ResponseBody]]
+    val sparkConf = getSparkConfForResourceStagingServerDownloads
+    val initContainerUnderTest = new KubernetesSparkDependencyDownloadInitContainer(
+      sparkConf,
+      retrofitClientFactory,
+      fileFetcher,
+      securityManager = new SparkSecurityManager(sparkConf))
     when(retrofitClient.downloadResources(JARS_RESOURCE_ID, downloadJarsSecretValue))
       .thenReturn(downloadJarsCall)
     when(retrofitClient.downloadResources(FILES_RESOURCE_ID, downloadFilesSecretValue))
@@ -125,6 +117,46 @@ class KubernetesSparkDependencyDownloadInitContainerSuite
     initContainerUnderTest.run()
     checkWrittenFilesAreTheSameAsOriginal(JARS, downloadJarsDir)
     checkWrittenFilesAreTheSameAsOriginal(FILES, downloadFilesDir)
+    Mockito.verifyZeroInteractions(fileFetcher)
+  }
+
+  test("Downloads from remote server should invoke the file fetcher") {
+    val sparkConf = getSparkConfForRemoteFileDownloads
+    val initContainerUnderTest = new KubernetesSparkDependencyDownloadInitContainer(
+      sparkConf,
+      retrofitClientFactory,
+      fileFetcher,
+      securityManager = new SparkSecurityManager(sparkConf))
+    initContainerUnderTest.run()
+    Mockito.verify(fileFetcher).fetchFile("http://localhost:9000/jar1.jar", downloadJarsDir)
+    Mockito.verify(fileFetcher).fetchFile("hdfs://localhost:9000/jar2.jar", downloadJarsDir)
+    Mockito.verify(fileFetcher).fetchFile("http://localhost:9000/file.txt", downloadFilesDir)
+
+  }
+
+  private def getSparkConfForResourceStagingServerDownloads: SparkConf = {
+    new SparkConf(true)
+      .set(RESOURCE_STAGING_SERVER_URI, STAGING_SERVER_URI)
+      .set(INIT_CONTAINER_DOWNLOAD_JARS_RESOURCE_IDENTIFIER, JARS_RESOURCE_ID)
+      .set(INIT_CONTAINER_DOWNLOAD_JARS_SECRET_LOCATION, DOWNLOAD_JARS_SECRET_LOCATION)
+      .set(INIT_CONTAINER_DOWNLOAD_FILES_RESOURCE_IDENTIFIER, FILES_RESOURCE_ID)
+      .set(INIT_CONTAINER_DOWNLOAD_FILES_SECRET_LOCATION, DOWNLOAD_FILES_SECRET_LOCATION)
+      .set(DRIVER_SUBMITTED_JARS_DOWNLOAD_LOCATION, downloadJarsDir.getAbsolutePath)
+      .set(DRIVER_SUBMITTED_FILES_DOWNLOAD_LOCATION, downloadFilesDir.getAbsolutePath)
+      .set(RESOURCE_STAGING_SERVER_SSL_ENABLED, true)
+      .set(RESOURCE_STAGING_SERVER_TRUSTSTORE_FILE, TRUSTSTORE_FILE.getAbsolutePath)
+      .set(RESOURCE_STAGING_SERVER_TRUSTSTORE_PASSWORD, TRUSTSTORE_PASSWORD)
+      .set(RESOURCE_STAGING_SERVER_TRUSTSTORE_TYPE, TRUSTSTORE_TYPE)
+  }
+
+  private def getSparkConfForRemoteFileDownloads: SparkConf = {
+    new SparkConf(true)
+      .set(INIT_CONTAINER_REMOTE_JARS,
+        "http://localhost:9000/jar1.jar,hdfs://localhost:9000/jar2.jar")
+      .set(INIT_CONTAINER_REMOTE_FILES,
+        "http://localhost:9000/file.txt")
+      .set(DRIVER_REMOTE_JARS_DOWNLOAD_LOCATION, downloadJarsDir.getAbsolutePath)
+      .set(DRIVER_REMOTE_FILES_DOWNLOAD_LOCATION, downloadFilesDir.getAbsolutePath)
   }
 
   private def checkWrittenFilesAreTheSameAsOriginal(

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -198,6 +198,28 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>copy-integration-test-http-server-dockerfile</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/docker/dockerfiles</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/docker</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
         <version>1.3.0</version>

--- a/resource-managers/kubernetes/integration-tests/src/main/docker/integration-test-asset-server/Dockerfile
+++ b/resource-managers/kubernetes/integration-tests/src/main/docker/integration-test-asset-server/Dockerfile
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Simple asset server that can provide the integration test jars over HTTP.
+FROM trinitronx/python-simplehttpserver:travis-12
+
+ADD examples/integration-tests-jars /var/www

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/KubernetesSuite.scala
@@ -42,9 +42,9 @@ private[spark] class KubernetesSuite extends SparkFunSuite {
   }
 
   override def nestedSuites: scala.collection.immutable.IndexedSeq[Suite] = {
-      Vector(
-        new KubernetesV1Suite,
-        new KubernetesV2Suite)
+    Vector(
+      new KubernetesV1Suite,
+      new KubernetesV2Suite)
   }
 }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/SparkReadinessWatcher.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/SparkReadinessWatcher.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.integrationtest
+
+import java.util.concurrent.TimeUnit
+
+import com.google.common.util.concurrent.SettableFuture
+import io.fabric8.kubernetes.api.model.HasMetadata
+import io.fabric8.kubernetes.client.{KubernetesClientException, Watcher}
+import io.fabric8.kubernetes.client.Watcher.Action
+import io.fabric8.kubernetes.client.internal.readiness.Readiness
+
+private[spark] class SparkReadinessWatcher[T <: HasMetadata] extends Watcher[T] {
+
+  private val signal = SettableFuture.create[Boolean]
+
+  override def eventReceived(action: Action, resource: T): Unit = {
+    if ((action == Action.MODIFIED || action == Action.ADDED) &&
+        Readiness.isReady(resource)) {
+      signal.set(true)
+    }
+  }
+
+  override def onClose(cause: KubernetesClientException): Unit = {}
+
+  def waitUntilReady(): Boolean = signal.get(30, TimeUnit.SECONDS)
+}

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/StaticAssetServerLauncher.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/StaticAssetServerLauncher.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.integrationtest
+
+import io.fabric8.kubernetes.api.model.{HTTPGetActionBuilder, Pod}
+import io.fabric8.kubernetes.client.KubernetesClient
+
+import org.apache.spark.util.Utils
+
+/**
+ * Launches a simple HTTP server which provides jars that can be downloaded by Spark applications
+ * in integration tests.
+ */
+private[spark] class StaticAssetServerLauncher(kubernetesClient: KubernetesClient) {
+
+  // Returns the HTTP Base URI of the server.
+  def launchStaticAssetServer(): String = {
+    val readinessWatcher = new SparkReadinessWatcher[Pod]
+    val probePingHttpGet = new HTTPGetActionBuilder()
+      .withNewPort(8080)
+      .withScheme("HTTP")
+      .withPath("/")
+      .build()
+    Utils.tryWithResource(kubernetesClient
+        .pods()
+        .withName("integration-test-static-assets")
+        .watch(readinessWatcher)) { _ =>
+      val pod = kubernetesClient.pods().createNew()
+        .withNewMetadata()
+          .withName("integration-test-static-assets")
+          .endMetadata()
+        .withNewSpec()
+          .addNewContainer()
+            .withName("static-asset-server-container")
+            .withImage("spark-integration-test-asset-server:latest")
+            .withImagePullPolicy("IfNotPresent")
+            .withNewReadinessProbe()
+              .withHttpGet(probePingHttpGet)
+              .endReadinessProbe()
+            .endContainer()
+          .endSpec()
+        .done()
+      readinessWatcher.waitUntilReady()
+      val podIP = kubernetesClient.pods().withName(pod.getMetadata.getName).get()
+        .getStatus
+        .getPodIP
+      s"http://$podIP:8080"
+    }
+  }
+}

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/docker/SparkDockerImageBuilder.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/docker/SparkDockerImageBuilder.scala
@@ -33,6 +33,8 @@ private[spark] class SparkDockerImageBuilder(private val dockerEnv: Map[String, 
   private val EXECUTOR_DOCKER_FILE = "dockerfiles/executor/Dockerfile"
   private val DRIVER_INIT_DOCKER_FILE = "dockerfiles/driver-init/Dockerfile"
   private val STAGING_SERVER_DOCKER_FILE = "dockerfiles/resource-staging-server/Dockerfile"
+  private val STATIC_ASSET_SERVER_DOCKER_FILE =
+    "dockerfiles/integration-test-asset-server/Dockerfile"
   private val TIMEOUT = PatienceConfiguration.Timeout(Span(2, Minutes))
   private val INTERVAL = PatienceConfiguration.Interval(Span(2, Seconds))
   private val dockerHost = dockerEnv.getOrElse("DOCKER_HOST",
@@ -63,6 +65,7 @@ private[spark] class SparkDockerImageBuilder(private val dockerEnv: Map[String, 
     buildImage("spark-driver-v2", DRIVER_V2_DOCKER_FILE)
     buildImage("spark-resource-staging-server", STAGING_SERVER_DOCKER_FILE)
     buildImage("spark-driver-init", DRIVER_INIT_DOCKER_FILE)
+    buildImage("spark-integration-test-asset-server", STATIC_ASSET_SERVER_DOCKER_FILE)
   }
 
   private def buildImage(name: String, dockerFile: String): Unit = {


### PR DESCRIPTION
Augments the init-container so that we don't need to use a separate image, but on submission two containers are bootstrapped for a cleaner architecture.