### PR TITLE
Build with sbt and fix scalastyle checks.

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -57,9 +57,11 @@ object BuildCommons {
   ).map(ProjectRef(buildLocation, _)) ++ sqlProjects ++ streamingProjects
 
   val optionallyEnabledProjects@Seq(mesos, yarn, java8Tests, sparkGangliaLgpl,
-    streamingKinesisAsl, dockerIntegrationTests) =
-    Seq("mesos", "yarn", "java8-tests", "ganglia-lgpl", "streaming-kinesis-asl",
-      "docker-integration-tests").map(ProjectRef(buildLocation, _))
+    streamingKinesisAsl, dockerIntegrationTests, kubernetes, _*) =
+    Seq("mesos", "yarn", "java8-tests", "ganglia-lgpl", "streaming-kinesis-asl", "docker-integration-tests",
+      "kubernetes", "kubernetes-integration-tests", "kubernetes-integration-tests-spark-jobs",
+      "kubernetes-integration-tests-spark-jobs-helpers", "kubernetes-docker-minimal-bundle"
+    ).map(ProjectRef(buildLocation, _))
 
   val assemblyProjects@Seq(networkYarn, streamingFlumeAssembly, streamingKafkaAssembly, streamingKafka010Assembly, streamingKinesisAslAssembly) =
     Seq("network-yarn", "streaming-flume-assembly", "streaming-kafka-0-8-assembly", "streaming-kafka-0-10-assembly", "streaming-kinesis-asl-assembly")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/SSLUtils.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/SSLUtils.scala
@@ -19,8 +19,8 @@ package org.apache.spark.deploy.kubernetes
 import java.io.{File, FileOutputStream, OutputStreamWriter}
 import java.math.BigInteger
 import java.nio.file.Files
-import java.security.cert.X509Certificate
 import java.security.{KeyPair, KeyPairGenerator, KeyStore, SecureRandom}
+import java.security.cert.X509Certificate
 import java.util.{Calendar, Random}
 import javax.security.auth.x500.X500Principal
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/submit/v2/ClientV2Suite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/submit/v2/ClientV2Suite.scala
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.api.model.{ConfigMap, ConfigMapBuilder, Container, 
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.{MixedOperation, NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable, PodResource}
 import org.hamcrest.{BaseMatcher, Description}
-import org.mockito.Matchers.{any, anyVararg, argThat, startsWith, eq => mockitoEq}
+import org.mockito.Matchers.{any, anyVararg, argThat, eq => mockitoEq, startsWith}
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/ResourceStagingServerSslOptionsProviderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/ResourceStagingServerSslOptionsProviderSuite.scala
@@ -96,7 +96,8 @@ class ResourceStagingServerSslOptionsProviderSuite extends SparkFunSuite with Be
       .set("spark.ssl.kubernetes.resourceStagingServer.keyStore", keyStoreFile.getAbsolutePath)
       .set("spark.ssl.kubernetes.resourceStagingServer.keyStorePasswordFile",
         keyStorePasswordFile.getAbsolutePath)
-      .set("spark.ssl.kubernetes.resourceStagingServer.keyPasswordFile", keyPasswordFile.getAbsolutePath)
+      .set("spark.ssl.kubernetes.resourceStagingServer.keyPasswordFile",
+        keyPasswordFile.getAbsolutePath)
     val sslOptions = sslOptionsProvider.getSslOptions
     assert(sslOptions.keyStorePassword === Some("keyStorePassword"),
       "Incorrect keyStore password or it was not set.")

--- a/resource-managers/kubernetes/docker-minimal-bundle/pom.xml
+++ b/resource-managers/kubernetes/docker-minimal-bundle/pom.xml
@@ -31,7 +31,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <sbt.project.name>docker-minimal-bundle</sbt.project.name>
+    <sbt.project.name>kubernetes-docker-minimal-bundle</sbt.project.name>
     <build.testJarPhase>none</build.testJarPhase>
     <build.copyDependenciesPhase>pre-integration-test</build.copyDependenciesPhase>
   </properties>

--- a/resource-managers/kubernetes/integration-tests-spark-jobs-helpers/pom.xml
+++ b/resource-managers/kubernetes/integration-tests-spark-jobs-helpers/pom.xml
@@ -27,6 +27,9 @@
   <artifactId>spark-kubernetes-integration-tests-spark-jobs-helpers_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Kubernetes Integration Tests Spark Jobs Helpers</name>
+  <properties>
+    <sbt.project.name>kubernetes-integration-tests-spark-jobs-helpers</sbt.project.name>
+  </properties>
 
   <dependencies>
   </dependencies>

--- a/resource-managers/kubernetes/integration-tests-spark-jobs/pom.xml
+++ b/resource-managers/kubernetes/integration-tests-spark-jobs/pom.xml
@@ -27,6 +27,9 @@
   <artifactId>spark-kubernetes-integration-tests-spark-jobs_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Kubernetes Integration Tests Spark Jobs</name>
+  <properties>
+    <sbt.project.name>kubernetes-integration-tests-spark-jobs</sbt.project.name>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -25,6 +25,9 @@
   </parent>
 
   <artifactId>spark-kubernetes-integration-tests_2.11</artifactId>
+  <properties>
+    <sbt.project.name>kubernetes-integration-tests</sbt.project.name>
+  </properties>
   <packaging>jar</packaging>
   <name>Spark Project Kubernetes Integration Tests</name>
 


### PR DESCRIPTION
I want to build the project with sbt mainly because i want to set it up with [ensime](https://github.com/ensime/ensime-server/).

However, the build with sbt (`./build/sbt -Pkubernetes -Phadoop-2.6 -Pkubernetes-integration-tests -Pmesos -Pyarn -Phive compile test:compile`) failed with scalastyle check errors:

```sh
$ ./dev/scalastyle
Scalastyle checks failed at following occurrences:
[error] /data/github/spark/spark-k8s/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/ResourceStagingServerSslOptionsProviderSui
te.scala:99: File line length exceeds 100 characters
[error] /data/github/spark/spark-k8s/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/SSLUtils.scala:23:0: import.ordering.wrongOrderInG
roup.message
[error] (kubernetes/test:scalastyle) errors exist
[error] Total time: 10 s, completed Apr 23, 2017 3:34:14 PM
```