### PR TITLE
edit readme with a working build example command

### DIFF
--- a/resource-managers/kubernetes/README.md
+++ b/resource-managers/kubernetes/README.md
@@ -14,10 +14,10 @@ important matters to keep in mind when developing this feature.
 
 # Building Spark with Kubernetes Support
 
-To build Spark with Kubernetes support, use the `kubernetes` profile when invoking Maven. For example, to simply compile
-the Kubernetes core implementation module along with its dependencies:
+To build Spark with Kubernetes support, use the `kubernetes` profile when invoking Maven.
 
-    build/mvn compile -Pkubernetes -pl resource-managers/kubernetes/core -am -DskipTests
+    git checkout branch-2.1-kubernetes
+    build/mvn package -Pkubernetes -DskipTests
 
 To build a distribution of Spark with Kubernetes support, use the `dev/make-distribution.sh` script, and add the
 `kubernetes` profile as part of the build arguments. Any other build arguments can be specified as one would expect when


### PR DESCRIPTION
The example command on the readme doesn't work:
```
build/mvn compile -Pkubernetes -pl resource-managers/kubernetes/core -am -DskipTests
```

This PR proposes to replace it with this package target that is working for me 
(and annotate with the branch to build)
```
git checkout branch-2.1-kubernetes
build/mvn package -Pkubernetes -DskipTests
```
