### PR TITLE
Allow client certificate PEM for resource staging server

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
@@ -364,8 +364,13 @@ package object config extends Logging {
   private[spark] val RESOURCE_STAGING_SERVER_SSL_NAMESPACE = "kubernetes.resourceStagingServer"
   private[spark] val RESOURCE_STAGING_SERVER_CERT_PEM =
     ConfigBuilder(s"spark.ssl.$RESOURCE_STAGING_SERVER_SSL_NAMESPACE.serverCertPem")
-      .doc("Certificate PEM file to use when having the Kubernetes dependency server" +
+      .doc("Certificate PEM file to use when having the resource staging server" +
         " listen on TLS.")
+      .stringConf
+      .createOptional
+  private[spark] val RESOURCE_STAGING_SERVER_CLIENT_CERT_PEM =
+    ConfigBuilder(s"spark.ssl.$RESOURCE_STAGING_SERVER_SSL_NAMESPACE.clientCertPem")
+      .doc("Certificate PEM file to use when the client contacts the resource staging server.")
       .stringConf
       .createOptional
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/Client.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.deploy.kubernetes.constants._
+import org.apache.spark.deploy.rest.kubernetes.v2.ResourceStagingServerSslOptionsProviderImpl
 import org.apache.spark.internal.Logging
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.util.Utils
@@ -267,8 +268,9 @@ private[spark] object Client {
     val appName = sparkConf.getOption("spark.app.name")
       .getOrElse("spark")
     val kubernetesAppId = s"$appName-$launchTime".toLowerCase.replaceAll("\\.", "-")
+    val sslOptionsProvider = new ResourceStagingServerSslOptionsProviderImpl(sparkConf)
     val initContainerComponentsProvider = new DriverInitContainerComponentsProviderImpl(
-      sparkConf, kubernetesAppId, sparkJars, sparkFiles)
+      sparkConf, kubernetesAppId, sparkJars, sparkFiles, sslOptionsProvider.getSslOptions)
     val kubernetesClientProvider = new SubmissionKubernetesClientProviderImpl(sparkConf)
     val kubernetesCredentialsMounterProvider =
         new DriverPodKubernetesCredentialsMounterProviderImpl(sparkConf, kubernetesAppId)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/DriverInitContainerComponentsProvider.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/DriverInitContainerComponentsProvider.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.deploy.kubernetes.submit.v2
 
-import org.apache.spark.{SecurityManager, SparkConf}
+import org.apache.spark.{SparkConf, SSLOptions}
 import org.apache.spark.deploy.kubernetes.{InitContainerResourceStagingServerSecretPluginImpl, SparkPodInitContainerBootstrap, SparkPodInitContainerBootstrapImpl}
 import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.deploy.kubernetes.constants._
@@ -46,12 +46,11 @@ private[spark] class DriverInitContainerComponentsProviderImpl(
     sparkConf: SparkConf,
     kubernetesAppId: String,
     sparkJars: Seq[String],
-    sparkFiles: Seq[String])
+    sparkFiles: Seq[String],
+    resourceStagingServerSslOptions: SSLOptions)
     extends DriverInitContainerComponentsProvider {
 
   private val maybeResourceStagingServerUri = sparkConf.get(RESOURCE_STAGING_SERVER_URI)
-  private val resourceStagingServerSslOptions = new SecurityManager(sparkConf)
-      .getSSLOptions(RESOURCE_STAGING_SERVER_SSL_NAMESPACE)
   private val jarsDownloadPath = sparkConf.get(INIT_CONTAINER_JARS_DOWNLOAD_LOCATION)
   private val filesDownloadPath = sparkConf.get(INIT_CONTAINER_FILES_DOWNLOAD_LOCATION)
   private val maybeSecretName = maybeResourceStagingServerUri.map { _ =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/SubmittedDependencySecretBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v2/SubmittedDependencySecretBuilder.scala
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.{Secret, SecretBuilder}
 import scala.collection.JavaConverters._
 
 import org.apache.spark.SSLOptions
-import org.apache.spark.deploy.kubernetes.constants._
 
 private[spark] trait SubmittedDependencySecretBuilder {
   /**

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/v2/ResourceStagingServerSslOptionsProvider.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/v2/ResourceStagingServerSslOptionsProvider.scala
@@ -17,9 +17,11 @@
 package org.apache.spark.deploy.rest.kubernetes.v2
 
 import java.io.File
+import java.security.SecureRandom
 
 import com.google.common.base.Charsets
 import com.google.common.io.Files
+import org.apache.commons.lang3.RandomStringUtils
 
 import org.apache.spark.{SecurityManager => SparkSecurityManager, SparkConf, SparkException, SSLOptions}
 import org.apache.spark.deploy.kubernetes.config._
@@ -32,20 +34,29 @@ private[spark] trait ResourceStagingServerSslOptionsProvider {
 
 private[spark] class ResourceStagingServerSslOptionsProviderImpl(sparkConf: SparkConf)
     extends ResourceStagingServerSslOptionsProvider with Logging {
+
+  private val SECURE_RANDOM = new SecureRandom()
+
   def getSslOptions: SSLOptions = {
     val baseSslOptions = new SparkSecurityManager(sparkConf)
-      .getSSLOptions("kubernetes.resourceStagingServer")
+      .getSSLOptions(RESOURCE_STAGING_SERVER_SSL_NAMESPACE)
     val maybeKeyPem = sparkConf.get(RESOURCE_STAGING_SERVER_KEY_PEM)
-    val maybeCertPem = sparkConf.get(RESOURCE_STAGING_SERVER_CERT_PEM)
+    val maybeServerCertPem = sparkConf.get(RESOURCE_STAGING_SERVER_CERT_PEM)
     val maybeKeyStorePasswordFile = sparkConf.get(RESOURCE_STAGING_SERVER_KEYSTORE_PASSWORD_FILE)
     val maybeKeyPasswordFile = sparkConf.get(RESOURCE_STAGING_SERVER_KEYSTORE_KEY_PASSWORD_FILE)
+    val maybeClientCertPem = sparkConf.get(RESOURCE_STAGING_SERVER_CLIENT_CERT_PEM)
 
     logSslConfigurations(
-      baseSslOptions, maybeKeyPem, maybeCertPem, maybeKeyStorePasswordFile, maybeKeyPasswordFile)
+      baseSslOptions,
+      maybeKeyPem,
+      maybeServerCertPem,
+      maybeKeyStorePasswordFile,
+      maybeKeyPasswordFile,
+      maybeClientCertPem)
 
     requireNandDefined(baseSslOptions.keyStore, maybeKeyPem,
       "Shouldn't provide both key PEM and keyStore files for TLS.")
-    requireNandDefined(baseSslOptions.keyStore, maybeCertPem,
+    requireNandDefined(baseSslOptions.keyStore, maybeServerCertPem,
       "Shouldn't provide both certificate PEM and keyStore files for TLS.")
     requireNandDefined(baseSslOptions.keyStorePassword, maybeKeyStorePasswordFile,
       "Shouldn't provide both the keyStore password value and the keyStore password file.")
@@ -53,42 +64,68 @@ private[spark] class ResourceStagingServerSslOptionsProviderImpl(sparkConf: Spar
       "Shouldn't provide both the keyStore key password value and the keyStore key password file.")
     requireBothOrNeitherDefined(
       maybeKeyPem,
-      maybeCertPem,
+      maybeServerCertPem,
       "When providing a certificate PEM file, the key PEM file must also be provided.",
       "When providing a key PEM file, the certificate PEM file must also be provided.")
+    requireNandDefined(baseSslOptions.trustStore, maybeClientCertPem,
+      "Shouldn't provide both the trustStore and a client certificate PEM file.")
 
     val resolvedKeyStorePassword = baseSslOptions.keyStorePassword
       .orElse(maybeKeyStorePasswordFile.map { keyStorePasswordFile =>
         safeFileToString(keyStorePasswordFile, "KeyStore password file")
       })
+      .orElse(maybeKeyPem.map { _ => randomPassword()})
     val resolvedKeyStoreKeyPassword = baseSslOptions.keyPassword
       .orElse(maybeKeyPasswordFile.map { keyPasswordFile =>
         safeFileToString(keyPasswordFile, "KeyStore key password file")
       })
-    val resolvedKeyStore = baseSslOptions.keyStore
-      .orElse(maybeKeyPem.map { keyPem =>
+      .orElse(maybeKeyPem.map { _ => randomPassword()})
+    val resolvedKeyStore = baseSslOptions.keyStore.orElse {
+      for {
+        keyPem <- maybeKeyPem
+        certPem <- maybeServerCertPem
+        keyStorePassword <- resolvedKeyStorePassword
+        keyPassword <- resolvedKeyStoreKeyPassword
+      } yield {
         val keyPemFile = new File(keyPem)
-        val certPemFile = new File(maybeCertPem.get)
+        val certPemFile = new File(certPem)
         PemsToKeyStoreConverter.convertPemsToTempKeyStoreFile(
           keyPemFile,
           certPemFile,
           "key",
-          resolvedKeyStorePassword,
-          resolvedKeyStoreKeyPassword,
+          keyStorePassword,
+          keyPassword,
           baseSslOptions.keyStoreType)
-      })
+      }
+    }
+    val resolvedTrustStorePassword = baseSslOptions.trustStorePassword
+      .orElse(maybeClientCertPem.map( _ => "defaultTrustStorePassword"))
+    val resolvedTrustStore = baseSslOptions.trustStore.orElse {
+      for {
+        clientCertPem <- maybeClientCertPem
+        trustStorePassword <- resolvedTrustStorePassword
+      } yield {
+        val certPemFile = new File(clientCertPem)
+        PemsToKeyStoreConverter.convertCertPemToTempTrustStoreFile(
+          certPemFile,
+          trustStorePassword,
+          baseSslOptions.trustStoreType)
+      }
+    }
     baseSslOptions.copy(
       keyStore = resolvedKeyStore,
       keyStorePassword = resolvedKeyStorePassword,
-      keyPassword = resolvedKeyStoreKeyPassword)
+      keyPassword = resolvedKeyStoreKeyPassword,
+      trustStore = resolvedTrustStore)
   }
 
   private def logSslConfigurations(
       baseSslOptions: SSLOptions,
       maybeKeyPem: Option[String],
-      maybeCertPem: Option[String],
+      maybeServerCertPem: Option[String],
       maybeKeyStorePasswordFile: Option[String],
-      maybeKeyPasswordFile: Option[String]) = {
+      maybeKeyPasswordFile: Option[String],
+      maybeClientCertPem: Option[String]) = {
     logDebug("The following SSL configurations were provided for the resource staging server:")
     logDebug(s"KeyStore File: ${baseSslOptions.keyStore.map(_.getAbsolutePath).getOrElse("N/A")}")
     logDebug("KeyStore Password: " +
@@ -99,7 +136,8 @@ private[spark] class ResourceStagingServerSslOptionsProviderImpl(sparkConf: Spar
     logDebug(s"Key Password File: ${maybeKeyPasswordFile.getOrElse("N/A")}")
     logDebug(s"KeyStore Type: ${baseSslOptions.keyStoreType.getOrElse("N/A")}")
     logDebug(s"Key PEM: ${maybeKeyPem.getOrElse("N/A")}")
-    logDebug(s"Certificate PEM: ${maybeCertPem.getOrElse("N/A")}")
+    logDebug(s"Server-side certificate PEM: ${maybeServerCertPem.getOrElse("N/A")}")
+    logDebug(s"Client-side certificate PEM: ${maybeClientCertPem.getOrElse("N/A")}")
   }
 
   private def requireBothOrNeitherDefined(
@@ -129,5 +167,9 @@ private[spark] class ResourceStagingServerSslOptionsProviderImpl(sparkConf: Spar
         + s" is not a file.")
     }
     Files.toString(file, Charsets.UTF_8)
+  }
+
+  private def randomPassword(): String = {
+    RandomStringUtils.random(1024, 0, Integer.MAX_VALUE, false, false, null, SECURE_RANDOM)
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/SSLUtils.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/SSLUtils.scala
@@ -30,6 +30,7 @@ import org.bouncycastle.cert.jcajce.{JcaX509CertificateConverter, JcaX509v3Certi
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 
+import org.apache.spark.deploy.kubernetes.submit.v2.{KeyAndCertPem, KeyStoreAndTrustStore}
 import org.apache.spark.util.Utils
 
 private[spark] object SSLUtils {
@@ -38,7 +39,7 @@ private[spark] object SSLUtils {
       ipAddress: String,
       keyStorePassword: String,
       keyPassword: String,
-      trustStorePassword: String): (File, File) = {
+      trustStorePassword: String): KeyStoreAndTrustStore = {
     val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
     keyPairGenerator.initialize(512)
     val keyPair = keyPairGenerator.generateKeyPair()
@@ -60,10 +61,10 @@ private[spark] object SSLUtils {
     Utils.tryWithResource(new FileOutputStream(trustStoreFile)) {
       trustStore.store(_, trustStorePassword.toCharArray)
     }
-    (keyStoreFile, trustStoreFile)
+    KeyStoreAndTrustStore(keyStoreFile, trustStoreFile)
   }
 
-  def generateKeyCertPemPair(ipAddress: String): (File, File) = {
+  def generateKeyCertPemPair(ipAddress: String): KeyAndCertPem = {
     val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
     keyPairGenerator.initialize(512)
     val keyPair = keyPairGenerator.generateKeyPair()
@@ -90,7 +91,7 @@ private[spark] object SSLUtils {
         }
       }
     }
-    (keyPemFile, certPemFile)
+    KeyAndCertPem(keyPemFile, certPemFile)
   }
 
   private def generateCertificate(ipAddress: String, keyPair: KeyPair): X509Certificate = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/submit/v2/SSLFilePairs.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/kubernetes/submit/v2/SSLFilePairs.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.submit.v2
+
+import java.io.File
+
+case class KeyAndCertPem(keyPem: File, certPem: File)
+
+case class KeyStoreAndTrustStore(keyStore: File, trustStore: File)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/KubernetesSparkDependencyDownloadInitContainerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/KubernetesSparkDependencyDownloadInitContainerSuite.scala
@@ -99,7 +99,7 @@ class KubernetesSparkDependencyDownloadInitContainerSuite
       sparkConf,
       retrofitClientFactory,
       fileFetcher,
-      securityManager = new SparkSecurityManager(sparkConf))
+      resourceStagingServerSslOptions = STAGING_SERVER_SSL_OPTIONS)
     when(retrofitClient.downloadResources(JARS_RESOURCE_ID, downloadJarsSecretValue))
       .thenReturn(downloadJarsCall)
     when(retrofitClient.downloadResources(FILES_RESOURCE_ID, downloadFilesSecretValue))
@@ -126,7 +126,7 @@ class KubernetesSparkDependencyDownloadInitContainerSuite
       sparkConf,
       retrofitClientFactory,
       fileFetcher,
-      securityManager = new SparkSecurityManager(sparkConf))
+      resourceStagingServerSslOptions = STAGING_SERVER_SSL_OPTIONS)
     initContainerUnderTest.run()
     Mockito.verify(fileFetcher).fetchFile("http://localhost:9000/jar1.jar", downloadJarsDir)
     Mockito.verify(fileFetcher).fetchFile("hdfs://localhost:9000/jar2.jar", downloadJarsDir)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/ResourceStagingServerSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/rest/kubernetes/v2/ResourceStagingServerSuite.scala
@@ -57,17 +57,17 @@ class ResourceStagingServerSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("Enable SSL on the server") {
-    val (keyStore, trustStore) = SSLUtils.generateKeyStoreTrustStorePair(
+    val keyStoreAndTrustStore = SSLUtils.generateKeyStoreTrustStorePair(
       ipAddress = "127.0.0.1",
       keyStorePassword = "keyStore",
       keyPassword = "key",
       trustStorePassword = "trustStore")
     val sslOptions = SSLOptions(
       enabled = true,
-      keyStore = Some(keyStore),
+      keyStore = Some(keyStoreAndTrustStore.keyStore),
       keyStorePassword = Some("keyStore"),
       keyPassword = Some("key"),
-      trustStore = Some(trustStore),
+      trustStore = Some(keyStoreAndTrustStore.trustStore),
       trustStorePassword = Some("trustStore"))
     sslOptionsProvider.setOptions(sslOptions)
     server.start()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/ResourceStagingServerLauncher.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/ResourceStagingServerLauncher.scala
@@ -16,21 +16,17 @@
  */
 package org.apache.spark.deploy.kubernetes.integrationtest
 
-import java.io.StringWriter
+import java.io.{File, StringWriter}
 import java.util.Properties
-import java.util.concurrent.TimeUnit
 
 import com.google.common.io.{BaseEncoding, Files}
-import com.google.common.util.concurrent.SettableFuture
-import io.fabric8.kubernetes.api.model.{ConfigMapBuilder, Endpoints, HasMetadata, HTTPGetActionBuilder, KeyToPathBuilder, Pod, PodBuilder, SecretBuilder, ServiceBuilder}
-import io.fabric8.kubernetes.client.{KubernetesClient, KubernetesClientException, Watcher}
-import io.fabric8.kubernetes.client.Watcher.Action
-import io.fabric8.kubernetes.client.internal.readiness.Readiness
+import io.fabric8.kubernetes.api.model.{ConfigMapBuilder, Endpoints, HTTPGetActionBuilder, KeyToPathBuilder, Pod, PodBuilder, SecretBuilder, ServiceBuilder}
+import io.fabric8.kubernetes.client.KubernetesClient
 import scala.collection.JavaConverters._
 
 import org.apache.spark.SSLOptions
 import org.apache.spark.deploy.kubernetes.config._
-import org.apache.spark.deploy.kubernetes.submit.v2.ContainerNameEqualityPredicate
+import org.apache.spark.deploy.kubernetes.submit.v2.{ContainerNameEqualityPredicate, KeyAndCertPem}
 import org.apache.spark.util.Utils
 
 /**
@@ -38,23 +34,39 @@ import org.apache.spark.util.Utils
  */
 private[spark] class ResourceStagingServerLauncher(kubernetesClient: KubernetesClient) {
 
-  private val KEYSTORE_DIR = "/mnt/secrets/spark-staging"
-  private val KEYSTORE_FILE = s"$KEYSTORE_DIR/keyStore"
+  private val SECRETS_ROOT_DIR = "/mnt/secrets/spark-staging"
+  private val KEYSTORE_SECRET_KEY = "keyStore"
+  private val KEYSTORE_FILE = s"$SECRETS_ROOT_DIR/$KEYSTORE_SECRET_KEY"
+  private val KEY_PEM_SECRET_KEY = "keyPem"
+  private val CERT_PEM_SECRET_KEY = "certPem"
+  private val KEY_PEM_FILE = s"$SECRETS_ROOT_DIR/$KEY_PEM_SECRET_KEY"
+  private val CERT_PEM_FILE = s"$SECRETS_ROOT_DIR/$CERT_PEM_SECRET_KEY"
+  private val SSL_SECRET_NAME = "resource-staging-server-ssl-secrets"
   private val PROPERTIES_FILE_NAME = "staging-server.properties"
   private val PROPERTIES_DIR = "/var/data/spark-staging-server"
   private val PROPERTIES_FILE_PATH = s"$PROPERTIES_DIR/$PROPERTIES_FILE_NAME"
 
   // Returns the NodePort the staging server is listening on
-  def launchStagingServer(sslOptions: SSLOptions): Int = {
+  def launchStagingServer(
+      sslOptions: SSLOptions,
+      keyAndCertPem: Option[KeyAndCertPem] = None): Int = {
     val stagingServerProperties = new Properties()
     val stagingServerSecret = sslOptions.keyStore.map { keyStore =>
       val keyStoreBytes = Files.toByteArray(keyStore)
       val keyStoreBase64 = BaseEncoding.base64().encode(keyStoreBytes)
+      Map(KEYSTORE_SECRET_KEY -> keyStoreBase64)
+    }.orElse {
+      keyAndCertPem.map { keyAndCert =>
+        val keyPemBytes = Files.toByteArray(keyAndCert.keyPem)
+        val keyPemBase64 = BaseEncoding.base64().encode(keyPemBytes)
+        val certPemBytes = Files.toByteArray(keyAndCert.certPem)
+        val certPemBase64 = BaseEncoding.base64().encode(certPemBytes)
+        Map(KEY_PEM_SECRET_KEY -> keyPemBase64, CERT_PEM_SECRET_KEY -> certPemBase64)
+      }
+    }.map { secretData =>
       new SecretBuilder()
-        .withNewMetadata()
-          .withName("resource-staging-server-keystore")
-          .endMetadata()
-        .addToData("keyStore", keyStoreBase64)
+        .withNewMetadata().withName(SSL_SECRET_NAME).endMetadata()
+        .withData(secretData.asJava)
         .build()
     }
     stagingServerProperties.setProperty(
@@ -67,9 +79,17 @@ private[spark] class ResourceStagingServerLauncher(kubernetesClient: KubernetesC
       stagingServerProperties.setProperty(
         "spark.ssl.kubernetes.resourceStagingServer.keyPassword", password)
     }
-    stagingServerSecret.foreach { _ =>
+    sslOptions.keyStore.foreach { _ =>
       stagingServerProperties.setProperty(
         "spark.ssl.kubernetes.resourceStagingServer.keyStore", KEYSTORE_FILE)
+    }
+    keyAndCertPem.foreach { _ =>
+      stagingServerProperties.setProperty(
+          RESOURCE_STAGING_SERVER_KEY_PEM.key, KEY_PEM_FILE)
+    }
+    keyAndCertPem.foreach { _ =>
+      stagingServerProperties.setProperty(
+          RESOURCE_STAGING_SERVER_CERT_PEM.key, CERT_PEM_FILE)
     }
     val propertiesWriter = new StringWriter()
     stagingServerProperties.store(propertiesWriter, "Resource staging server properties.")
@@ -126,7 +146,7 @@ private[spark] class ResourceStagingServerLauncher(kubernetesClient: KubernetesC
         .editMatchingContainer(new ContainerNameEqualityPredicate("staging-server-container"))
           .addNewVolumeMount()
             .withName("keystore-volume")
-            .withMountPath(KEYSTORE_DIR)
+            .withMountPath(SECRETS_ROOT_DIR)
             .endVolumeMount()
           .endContainer()
         .endSpec()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/backend/minikube/MinikubeTestBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/backend/minikube/MinikubeTestBackend.scala
@@ -42,6 +42,4 @@ private[spark] class MinikubeTestBackend extends IntegrationTestBackend {
   }
 
   override def name(): String = MINIKUBE_TEST_BACKEND
-
-
 }


### PR DESCRIPTION
Allows the TLS certificate for reaching the resource staging server to be specified as a PEM file from the submitter's disk. Note that this is still uploaded as a trustStore file into the init-container - the client creates a temporary trustStore file from the certificate PEM. This is to simplify the secret generation so that we don't have to worry about differentiating between mounting the PEM vs. mounting a trustStore.

Depends on #246 which in turn depends on #251 .