### PR TITLE
Correct readme links

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -189,7 +189,7 @@ from the other deployment modes. See the [configuration page](configuration.html
   <td>
     The namespace that will be used for running the driver and executor pods. When using
     <code>spark-submit</code> in cluster mode, this can also be passed to <code>spark-submit</code> via the
-    <code>--kubernetes-namespace</code> command line argument.
+    <code>--kubernetes-namespace</code> command line argument. The namespace must already exist.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the links inside the Kubernetes readme. They pointed to `html` which are `md`resources. Also I added a note that the Kubernetes namespace must be already present and won't be created if absent.