### PR TITLE
Fix watcher conditional logic

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v1/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/v1/Client.scala
@@ -538,7 +538,9 @@ private[spark] class Client(
   private class DriverEndpointsReadyWatcher(resolvedDriverEndpoints: SettableFuture[Endpoints])
       extends Watcher[Endpoints] {
     override def eventReceived(action: Action, endpoints: Endpoints): Unit = {
-      if ((action == Action.ADDED) || (action == Action.MODIFIED)
+      if ((action == Action.ADDED || action == Action.MODIFIED)
+          && (endpoints != null)
+          && (endpoints.getSubsets != null)
           && endpoints.getSubsets.asScala.nonEmpty
           && endpoints.getSubsets.asScala.exists(_.getAddresses.asScala.nonEmpty)
           && !resolvedDriverEndpoints.isDone) {
@@ -554,7 +556,7 @@ private[spark] class Client(
   private class DriverServiceReadyWatcher(resolvedDriverService: SettableFuture[Service])
       extends Watcher[Service] {
     override def eventReceived(action: Action, service: Service): Unit = {
-      if ((action == Action.ADDED) || (action == Action.MODIFIED)
+      if ((action == Action.ADDED || action == Action.MODIFIED)
           && !resolvedDriverService.isDone) {
         resolvedDriverService.set(service)
       }


### PR DESCRIPTION
I ran into some exceptions being thrown from the endpoint watcher in the submission client.  It turned out that `null` values were being returned for `endpoints.getSubsets`, instead of just empty collection.  I added some guarding checks for `null`, which fixed the problem.

I also modified the parentheses around action types, because that appeared incorrect.  I believe it should be checking for `(action == added || action == modified)` as a unit in the first clause.
