### PR TITLE
Remove leading slash from Retrofit interface.

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/ResourceStagingServiceRetrofit.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/ResourceStagingServiceRetrofit.scala
@@ -29,7 +29,7 @@ import org.apache.spark.deploy.kubernetes.submit.SubmittedResourceIdAndSecret
 private[spark] trait ResourceStagingServiceRetrofit {
 
   @Multipart
-  @retrofit2.http.POST("/api/v0/resources/")
+  @retrofit2.http.POST("api/v0/resources/")
   def uploadResources(
       @retrofit2.http.Part("podLabels") podLabels: RequestBody,
       @retrofit2.http.Part("podNamespace") podNamespace: RequestBody,
@@ -38,7 +38,7 @@ private[spark] trait ResourceStagingServiceRetrofit {
           kubernetesCredentials: RequestBody): Call[SubmittedResourceIdAndSecret]
 
   @Streaming
-  @retrofit2.http.GET("/api/v0/resources/{resourceId}")
+  @retrofit2.http.GET("api/v0/resources/{resourceId}")
   def downloadResources(
     @Path("resourceId") resourceId: String,
     @retrofit2.http.Header("Authorization") resourceSecret: String): Call[ResponseBody]

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/RetrofitClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/rest/kubernetes/RetrofitClientFactory.scala
@@ -85,8 +85,13 @@ private[spark] object RetrofitClientFactoryImpl extends RetrofitClientFactory wi
       okHttpClientBuilder.sslSocketFactory(sslContext.getSocketFactory,
         trustManagers(0).asInstanceOf[X509TrustManager])
     }
+    val resolvedBaseUrl = if (!baseUrl.endsWith("/")) {
+      s"$baseUrl/"
+    } else {
+      baseUrl
+    }
     new Retrofit.Builder()
-      .baseUrl(baseUrl)
+      .baseUrl(resolvedBaseUrl)
       .addConverterFactory(ScalarsConverterFactory.create())
       .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))
       .client(okHttpClientBuilder.build())


### PR DESCRIPTION
Otherwise since the base URL has to end with a slash, but the retrofit interface has a leading slash, URLs result in `https://baseurl:9000/my/path//api/v0`... which of course strips out `/my/path`.