### PR TITLE
set driver pod restartPolicy to Never

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/Client.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/Client.scala
@@ -119,6 +119,7 @@ private[spark] class Client(
           .addToAnnotations(parsedCustomAnnotations.asJava)
           .endMetadata()
         .withNewSpec()
+          .withRestartPolicy("Never")
           .addToContainers(driverContainer)
           .endSpec()
 


### PR DESCRIPTION
V2 client not setting RestartPolicy, so using a default value "always", means the driverPod would be continuouslly restarted
