### PR TITLE
Fix client to await the driver pod

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/LoggingPodStatusWatcher.scala
@@ -137,7 +137,7 @@ private[kubernetes] class LoggingPodStatusWatcherImpl(
   }
 
   override def awaitCompletion(): Unit = {
-    podCompletedFuture.countDown()
+    podCompletedFuture.await()
     logInfo(pod.map { p =>
       s"Container final statuses:\n\n${containersDescription(p)}"
     }.getOrElse("No containers were found in the driver pod."))


### PR DESCRIPTION
@foxish @mccheah 

It seems there is a small bug in the current client code. My client exits right away without waiting for the driver pod to complete.

> 2017-06-02 14:48:36 INFO Client:54 - Waiting for application spark-hdfstest-1496440110123 to finish...
2017-06-02 14:48:36 INFO LoggingPodStatusWatcherImpl:54 - Container final statuses:
Container name: spark-kubernetes-driver
Container image: docker:5000/spark-driver:kimoon-0602-1
Container state: Waiting
Pending reason: PodInitializing
2017-06-02 14:48:36 INFO Client:54 - Application spark-hdfstest-1496440110123 finished.

Think it should have been podCompletedFuture.await below instead of countDown:

```
override def awaitCompletion(): Unit = {
    podCompletedFuture.countDown()
    logInfo(pod.map { p =>
      s”Container final statuses:\n\n${containersDescription(p)}”
    }.getOrElse(“No containers were found in the driver pod.“))
  }
```

The client waits for the driver to finish after this patch.

```
2017-06-02 15:27:41 INFO  LoggingPodStatusWatcherImpl:54 - Container final statuses:


	 Container name: spark-kubernetes-driver
	 Container image: docker:5000/spark-driver:kimoon-0602-1
	 Container state: Terminated
	 Exit code: 0
2017-06-02 15:27:41 INFO  Client:54 - Application spark-hdfstest-1496442152207 finished.
2017-06-02 15:27:41 INFO  ShutdownHookManager:54 - Shutdown hook called
2017-06-02 15:27:41 INFO  ShutdownHookManager:54 - Deleting directory /private/var/folders/6t/m6rqw14s78gbm3ggzsxg_ypr0000gp/T/uploaded-jars-2d319a09-877c-4264-92ec-dd85a24e97ac
2017-06-02 15:27:41 INFO  ShutdownHookManager:54 - Deleting directory /private/var/folders/6t/m6rqw14s78gbm3ggzsxg_ypr0000gp/T/uploaded-files-9a5b0e9f-1b83-483a-9e46-52017fa3f574
```