### PR TITLE
[WIP] Use HDFS Delegation Token in driver/executor pods as part of Secure HDFS Support

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
@@ -69,7 +69,17 @@ package object config extends Logging {
   private[spark] val CLIENT_CERT_FILE_CONF_SUFFIX = "clientCertFile"
   private[spark] val CA_CERT_FILE_CONF_SUFFIX = "caCertFile"
 
-  private[spark] val MOUNTED_HADOOP_SECRET_CONF = "spark.kubernetes.mounted.hadoopSecret"
+  // TODO: This option is intended to be used for internal prototype only until the submission
+  // client automatically creates the secret file. Remove this option afterward
+  // unless other use is found.
+  private[spark] val MOUNTED_HADOOP_SECRET_CONF =
+    ConfigBuilder("spark.kubernetes.mounted.hadoopSecret")
+        .doc("Use a Kubernetes secret containing Hadoop tokens such as an HDFS delegation token." +
+          " The secret should have an entry named 'hadoop-token-file' under the data section," +
+          " which contains binary dumps of Hadoop tokens.")
+        .internal()
+        .stringConf
+        .createOptional
 
   private[spark] val RESOURCE_STAGING_SERVER_USE_SERVICE_ACCOUNT_CREDENTIALS =
     ConfigBuilder(

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/config.scala
@@ -69,6 +69,8 @@ package object config extends Logging {
   private[spark] val CLIENT_CERT_FILE_CONF_SUFFIX = "clientCertFile"
   private[spark] val CA_CERT_FILE_CONF_SUFFIX = "caCertFile"
 
+  private[spark] val MOUNTED_HADOOP_SECRET_CONF = "spark.kubernetes.mounted.hadoopSecret"
+
   private[spark] val RESOURCE_STAGING_SERVER_USE_SERVICE_ACCOUNT_CREDENTIALS =
     ConfigBuilder(
           s"$APISERVER_AUTH_RESOURCE_STAGING_SERVER_CONF_PREFIX.useServiceAccountCredentials")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/constants.scala
@@ -43,6 +43,13 @@ package object constants {
     s"$DRIVER_CREDENTIALS_SECRETS_BASE_DIR/$DRIVER_CREDENTIALS_OAUTH_TOKEN_SECRET_NAME"
   private[spark] val DRIVER_CREDENTIALS_SECRET_VOLUME_NAME = "kubernetes-credentials"
 
+  // Hadoop credentials secrets for the Spark app.
+  private[spark] val SPARK_APP_HADOOP_CREDENTIALS_BASE_DIR = "/mnt/secrets/hadoop-credentials"
+  private[spark] val SPARK_APP_HADOOP_TOKEN_FILE_SECRET_NAME = "hadoop-token-file"
+  private[spark] val SPARK_APP_HADOOP_TOKEN_FILE_PATH =
+    s"$SPARK_APP_HADOOP_CREDENTIALS_BASE_DIR/$SPARK_APP_HADOOP_TOKEN_FILE_SECRET_NAME"
+  private[spark] val SPARK_APP_HADOOP_SECRET_VOLUME_NAME = "hadoop-secret"
+
   // Default and fixed ports
   private[spark] val SUBMISSION_SERVER_PORT = 7077
   private[spark] val DEFAULT_DRIVER_PORT = 7078
@@ -69,6 +76,7 @@ package object constants {
   private[spark] val ENV_MOUNTED_FILES_DIR = "SPARK_MOUNTED_FILES_DIR"
   private[spark] val ENV_PYSPARK_FILES = "PYSPARK_FILES"
   private[spark] val ENV_PYSPARK_PRIMARY = "PYSPARK_PRIMARY"
+  private[spark] val ENV_HADOOP_TOKEN_FILE_LOCATION = "HADOOP_TOKEN_FILE_LOCATION"
 
   // Bootstrapping dependencies with the init-container
   private[spark] val INIT_CONTAINER_ANNOTATION = "pod.beta.kubernetes.io/init-containers"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/DriverConfigurationStepsOrchestrator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/DriverConfigurationStepsOrchestrator.scala
@@ -20,7 +20,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.deploy.kubernetes.ConfigurationUtils
 import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.deploy.kubernetes.constants._
-import org.apache.spark.deploy.kubernetes.submit.submitsteps.{BaseDriverConfigurationStep, DependencyResolutionStep, DriverConfigurationStep, DriverKubernetesCredentialsStep, InitContainerBootstrapStep, PythonStep}
+import org.apache.spark.deploy.kubernetes.submit.submitsteps._
 import org.apache.spark.deploy.kubernetes.submit.submitsteps.initcontainer.InitContainerConfigurationStepsOrchestrator
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.util.Utils
@@ -94,7 +94,7 @@ private[spark] class DriverConfigurationStepsOrchestrator(
         submissionSparkConf)
     val kubernetesCredentialsStep = new DriverKubernetesCredentialsStep(
         submissionSparkConf, kubernetesResourceNamePrefix)
-    val hadoopTokensStep = new DriverHadoopTokensStep(submissionSparkConf)
+    val hadoopCredentialsStep = new DriverHadoopCredentialsStep(submissionSparkConf)
     val pythonStep = mainAppResource match {
       case PythonMainAppResource(mainPyResource) =>
         Option(new PythonStep(mainPyResource, additionalPythonFiles, filesDownloadPath))
@@ -132,7 +132,7 @@ private[spark] class DriverConfigurationStepsOrchestrator(
     Seq(
       initialSubmissionStep,
       kubernetesCredentialsStep,
-      hadoopTokensStep,
+      hadoopCredentialsStep,
       dependencyResolutionStep) ++
       initContainerBootstrapStep.toSeq ++
       pythonStep.toSeq

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/DriverConfigurationStepsOrchestrator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/DriverConfigurationStepsOrchestrator.scala
@@ -94,6 +94,7 @@ private[spark] class DriverConfigurationStepsOrchestrator(
         submissionSparkConf)
     val kubernetesCredentialsStep = new DriverKubernetesCredentialsStep(
         submissionSparkConf, kubernetesResourceNamePrefix)
+    val hadoopTokensStep = new DriverHadoopTokensStep(submissionSparkConf)
     val pythonStep = mainAppResource match {
       case PythonMainAppResource(mainPyResource) =>
         Option(new PythonStep(mainPyResource, additionalPythonFiles, filesDownloadPath))
@@ -131,6 +132,7 @@ private[spark] class DriverConfigurationStepsOrchestrator(
     Seq(
       initialSubmissionStep,
       kubernetesCredentialsStep,
+      hadoopTokensStep,
       dependencyResolutionStep) ++
       initContainerBootstrapStep.toSeq ++
       pythonStep.toSeq

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/HadoopSecretUtil.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/HadoopSecretUtil.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.submit
+
+import io.fabric8.kubernetes.api.model.{Container, ContainerBuilder, Pod, PodBuilder}
+
+import org.apache.spark.deploy.kubernetes.constants._
+
+object HadoopSecretUtil {
+
+  def configurePod(secretNameOption: Option[String], pod: Pod) : Pod = {
+    secretNameOption.map { secret =>
+      new PodBuilder(pod)
+        .editOrNewSpec()
+        .addNewVolume()
+        .withName(SPARK_APP_HADOOP_SECRET_VOLUME_NAME)
+        .withNewSecret()
+        .withSecretName(secret)
+        .endSecret()
+        .endVolume()
+        .endSpec()
+        .build()
+    }.getOrElse(pod)
+  }
+
+  def configureContainer(secretNameOption: Option[String],
+                         containerSpec: Container) : Container = {
+    secretNameOption.map { secret =>
+      new ContainerBuilder(containerSpec)
+        .addNewVolumeMount()
+        .withName(SPARK_APP_HADOOP_SECRET_VOLUME_NAME)
+        .withMountPath(SPARK_APP_HADOOP_CREDENTIALS_BASE_DIR)
+        .endVolumeMount()
+        .addNewEnv()
+        .withName(ENV_HADOOP_TOKEN_FILE_LOCATION)
+        .withValue(SPARK_APP_HADOOP_TOKEN_FILE_PATH)
+        .endEnv()
+        .build()
+    }.getOrElse(containerSpec)
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/submitsteps/DriverHadoopCredentialsStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/submitsteps/DriverHadoopCredentialsStep.scala
@@ -29,11 +29,10 @@ private[spark] class DriverHadoopCredentialsStep(submissionSparkConf: SparkConf)
     val podWithMountedHadoopToken = HadoopSecretUtil.configurePod(maybeMountedHadoopSecret,
       driverSpec.driverPod)
     val containerWithMountedHadoopToken = HadoopSecretUtil.configureContainer(
-      maybeMountedHadoopSecret, driverSpec.driverContainer)
+      maybeMountedHadoopSecret,
+      driverSpec.driverContainer)
     driverSpec.copy(
       driverPod = podWithMountedHadoopToken,
-      otherKubernetesResources = driverSpec.otherKubernetesResources,
-      driverSparkConf = driverSpec.driverSparkConf,
       driverContainer = containerWithMountedHadoopToken)
   }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/submitsteps/DriverHadoopCredentialsStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/submitsteps/DriverHadoopCredentialsStep.scala
@@ -23,7 +23,7 @@ import org.apache.spark.deploy.kubernetes.config._
 import org.apache.spark.deploy.kubernetes.constants._
 
 
-class DriverHadoopTokensStep(submissionSparkConf: SparkConf) extends DriverConfigurationStep {
+class DriverHadoopCredentialsStep(submissionSparkConf: SparkConf) extends DriverConfigurationStep {
 
   private val maybeMountedHadoopSecret = submissionSparkConf.getOption(MOUNTED_HADOOP_SECRET_CONF)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/submitsteps/DriverHadoopCredentialsStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/submitsteps/DriverHadoopCredentialsStep.scala
@@ -23,7 +23,7 @@ import org.apache.spark.deploy.kubernetes.submit.HadoopSecretUtil
 private[spark] class DriverHadoopCredentialsStep(submissionSparkConf: SparkConf)
   extends DriverConfigurationStep {
 
-  private val maybeMountedHadoopSecret = submissionSparkConf.getOption(MOUNTED_HADOOP_SECRET_CONF)
+  private val maybeMountedHadoopSecret = submissionSparkConf.get(MOUNTED_HADOOP_SECRET_CONF)
 
   override def configureDriver(driverSpec: KubernetesDriverSpec): KubernetesDriverSpec = {
     val podWithMountedHadoopToken = HadoopSecretUtil.configurePod(maybeMountedHadoopSecret,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/submitsteps/DriverHadoopTokensStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/kubernetes/submit/submitsteps/DriverHadoopTokensStep.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.kubernetes.submit.submitsteps
+
+import io.fabric8.kubernetes.api.model.{ContainerBuilder, PodBuilder}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.kubernetes.config._
+import org.apache.spark.deploy.kubernetes.constants._
+
+
+class DriverHadoopTokensStep(submissionSparkConf: SparkConf) extends DriverConfigurationStep {
+
+  private val maybeMountedHadoopSecret = submissionSparkConf.getOption(MOUNTED_HADOOP_SECRET_CONF)
+
+  override def configureDriver(driverSpec: KubernetesDriverSpec): KubernetesDriverSpec = {
+    val driverPodWithMountedHadoopTokens = maybeMountedHadoopSecret.map { secret =>
+      new PodBuilder(driverSpec.driverPod)
+        .editOrNewSpec()
+          .addNewVolume()
+            .withName(SPARK_APP_HADOOP_SECRET_VOLUME_NAME)
+            .withNewSecret()
+              .withSecretName(secret)
+            .endSecret()
+          .endVolume()
+        .endSpec()
+        .build()
+    }.getOrElse(driverSpec.driverPod)
+    val driverContainerWithMountedSecretVolume = maybeMountedHadoopSecret.map { secret =>
+      new ContainerBuilder(driverSpec.driverContainer)
+          .addNewVolumeMount()
+            .withName(SPARK_APP_HADOOP_SECRET_VOLUME_NAME)
+            .withMountPath(SPARK_APP_HADOOP_CREDENTIALS_BASE_DIR)
+          .endVolumeMount()
+          .addNewEnv()
+            .withName(ENV_HADOOP_TOKEN_FILE_LOCATION)
+            .withValue(SPARK_APP_HADOOP_TOKEN_FILE_PATH)
+          .endEnv()
+        .build()
+    }.getOrElse(driverSpec.driverContainer)
+    driverSpec.copy(
+      driverPod = driverPodWithMountedHadoopTokens,
+      otherKubernetesResources = driverSpec.otherKubernetesResources,
+      driverSparkConf = driverSpec.driverSparkConf,
+      driverContainer = driverContainerWithMountedSecretVolume)
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -130,7 +130,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   private implicit val requestExecutorContext = ExecutionContext.fromExecutorService(
     ThreadUtils.newDaemonCachedThreadPool("kubernetes-executor-requests"))
 
-  private val maybeMountedHadoopSecret = conf.getOption(MOUNTED_HADOOP_SECRET_CONF)
+  private val maybeMountedHadoopSecret = conf.get(MOUNTED_HADOOP_SECRET_CONF)
 
   private val driverPod = try {
     kubernetesClient.pods().inNamespace(kubernetesNamespace).


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is stage 3 of Secure HDFS Support, which is an on-going work of setting up Secure HDFS interaction with Spark-on-K8S. This change should be integrated with Stage 1 - 2, being implemented in other PRs.

The architecture is discussed in this community-wide google [doc](https://docs.google.com/document/d/1RBnXD9jMDjGonOdKJ2bA1lN4AAV_1RwpU_ewFuCNWKg)
This initiative can be broken down into 4 stages.

STAGE 1

- [ ] Detecting HADOOP_CONF_DIR environmental variable and using Config Maps to store all Hadoop config files locally, while also setting HADOOP_CONF_DIR locally in the driver / executors

STAGE 2

- [ ] Grabbing TGT from LTC or using keytabs+principle and creating a DT that will be mounted as a secret

STAGE 3
- [x] Driver + Executor Logic

STAGE 4

- [ ] Service Pod that handles renewals

## How was this patch tested?

Manually tested with the following steps. (Note step 1 - 3 and use of the pre-created secret below will go away when the submission client generates the secret automatically)

1. Obtain an HDFS delegation token after signing on with Kerberos. (See this google [doc](https://docs.google.com/document/d/1Lzi6R5jPJtMzNsnasjDomiwLS3jAQ5AgOxZF0DmIHIw/edit#heading=h.nnukcko18uok) for the source code of MyHdfsCredentialsUser)
```
$ kinit user1
$ hadoop com.pepperdata.MyHdfsCredentialsUser /tmp/hadoop-token-file
```

2. Copy the `/tmp/hadoop-token-file` to your Macbook.

3. Create a K8s secret from the file
```
$ kubectl create secret generic kimoon-hadoop-token-file --from-file hadoop-token-file
$ kubectl get secret -o json kimoon-hadoop-token-file
{
    "apiVersion": "v1",
    "data": {
        "hadoop-token-file": "SERUUwABDjEwLjMyLjAuNDo4MDIwLAAUdXNlcjFAUEVQUEVSREFUQS5DT00EeWFybgCKAV1Xc4d7igFde4ALewcVFEVJSbfCLNmgyRYhAewiuuMmHF8TFUhERlNfREVMRUdBVElPTl9UT0tFTg4xMC4zMi4wLjQ6ODAyMAA="
    },
    "kind": "Secret",
    "metadata": {
        "creationTimestamp": "2017-07-18T20:46:55Z",
        "name": "kimoon-hadoop-token-file",
        "namespace": "default",
        "resourceVersion": "22675361",
        "selfLink": "/api/v1/namespaces/default/secrets/kimoon-hadoop-token-file",
        "uid": "3c36588f-6bfa-11e7-9e51-02f2c310e88c"
    },
    "type": "Opaque"
}
```

4. Finally, submit a job while specifying the secret name as a config key
```
$ /usr/local/spark-on-k8s/bin/spark-submit  \
  --class org.apache.spark.examples.HdfsTest  \
  --conf spark.app.name=spark-hdfs  \
  --conf spark.executor.instances=1  \
  --conf spark.hadoop.fs.defaultFS=hdfs://10.32.0.4:8020  \
  --conf spark.kubernetes.mounted.hadoopSecret=kimoon-hadoop-token-file  \
   local:///opt/spark/examples/jars/spark-examples_2.11-2.1.0-k8s-0.2.0-SNAPSHOT.jar  \
  /tmp/etc-hosts
```

From the debug-enabled log, we can see "TOKEN" is used as authentication mechanism for the secure namenode.

>17/07/18 22:54:45 DEBUG SaslRpcClient: Sending sasl message state: NEGOTIATE
17/07/18 22:54:45 DEBUG SaslRpcClient: Received SASL message state: NEGOTIATE
auths {
  method: "TOKEN"
  mechanism: "DIGEST-MD5"
  protocol: ""
  serverId: "default"
  challenge: "realm=\"default\",nonce=\"HwXTpS3npEOeYBV/MK9D97oPqKg+ita8HfttmdMk\",qop=\"auth\",charset=utf-8,algorithm=md5-sess"
}
auths {
  method: "KERBEROS"
  mechanism: "GSSAPI"
  protocol: "hdfs"
  serverId: "cdh58-kimoon-rc-3839w"
}
17/07/18 22:54:45 DEBUG SaslRpcClient: Get token info proto:interface org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolPB info:@org.apache.hadoop.security.token.TokenInfo(value=class org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenSelector)
17/07/18 22:54:45 DEBUG SaslRpcClient: Creating SASL DIGEST-MD5(TOKEN)  client to authenticate to service at default
17/07/18 22:54:45 DEBUG SaslRpcClient: Use TOKEN authentication for protocol ClientNamenodeProtocolPB
17/07/18 22:54:45 DEBUG SaslRpcClient: SASL client callback: setting username: ABR1c2VyMUBQRVBQRVJEQVRBLkNPTQR5YXJuAIoBXVdzh3uKAV17gAt7BxU=
17/07/18 22:54:45 DEBUG SaslRpcClient: SASL client callback: setting userPassword
17/07/18 22:54:45 DEBUG SaslRpcClient: SASL client callback: setting realm: default
17/07/18 22:54:45 DEBUG SaslRpcClient: Sending sasl message state: INITIATE
token: "charset=utf-8,username=\"ABR1c2VyMUBQRVBQRVJEQVRBLkNPTQR5YXJuAIoBXVdzh3uKAV17gAt7BxU=\",realm=\"default\",nonce=\"HwXTpS3npEOeYBV/MK9D97oPqKg+ita8HfttmdMk\",nc=00000001,cnonce=\"kgMSsxud74r2fQr9/rURFPIW6gP++5IMj+0WxgEz\",digest-uri=\"/default\",maxbuf=65536,response=7a79b9ba186f3e84f2c5c90f3e7d49d8,qop=auth"
auths {
  method: "TOKEN"
  mechanism: "DIGEST-MD5"
  protocol: ""
  serverId: "default"
}
17/07/18 22:54:45 DEBUG SaslRpcClient: Received SASL message state: SUCCESS


The job will fail without the DT secret. Here's the failing job's log where the driver can't use either TOKEN nor KERBEROS authentication. Note the driver pod is not configured to enable Kerberos, which would be ok as long as there is a valid DT like the successful job run above:
> Exception in thread "main" org.apache.hadoop.security.AccessControlException: SIMPLE authentication is not enabled.  Available:[TOKEN, KERBEROS]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.apache.hadoop.ipc.RemoteException.instantiateException(RemoteException.java:106)
        at org.apache.hadoop.ipc.RemoteException.unwrapRemoteException(RemoteException.java:73)
        at org.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:2110)
        at org.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1305)
        at org.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1301)
        at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
        at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1317)
        at org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1426)
        at org.apache.spark.sql.execution.datasources.DataSource$$anonfun$14.apply(DataSource.scala:381)
        at org.apache.spark.sql.execution.datasources.DataSource$$anonfun$14.apply(DataSource.scala:370)
        at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:241)
        at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:241)
        at scala.collection.immutable.List.foreach(List.scala:381)
        at scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:241)
        at scala.collection.immutable.List.flatMap(List.scala:344)
        at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:370)
        at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:152)
        at org.apache.spark.sql.DataFrameReader.text(DataFrameReader.scala:506)
        at org.apache.spark.sql.DataFrameReader.text(DataFrameReader.scala:486)
        at org.apache.spark.examples.HdfsTest$.main(HdfsTest.scala:36)
        at org.apache.spark.examples.HdfsTest.main(HdfsTest.scala)
Caused by: org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.AccessControlException): SIMPLE authentication is not enabled.  Available:[TOKEN, KERBEROS]
        at org.apache.hadoop.ipc.Client.call(Client.java:1475)
        at org.apache.hadoop.ipc.Client.call(Client.java:1412)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:229)
        at com.sun.proxy.$Proxy31.getFileInfo(Unknown Source)
        at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:771)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:191)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)
        at com.sun.proxy.$Proxy32.getFileInfo(Unknown Source)
        at org.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:2108)
        ... 18 more