### PR TITLE
Changing submission logic to accommodate Spark shell applications

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -344,7 +344,7 @@ object SparkSubmit extends CommandLineUtils {
 
     // The following modes are not supported or applicable
     (clusterManager, deployMode) match {
-      case (KUBERNETES, CLIENT) =>
+      case (KUBERNETES, CLIENT) if !isShell(args.primaryResource) =>
         printErrorAndExit("Client mode is currently not supported for Kubernetes.")
       case (KUBERNETES, CLUSTER) if args.isR =>
         printErrorAndExit("Kubernetes does not currently support R applications.")
@@ -356,8 +356,12 @@ object SparkSubmit extends CommandLineUtils {
           "applications on standalone clusters.")
       case (LOCAL, CLUSTER) =>
         printErrorAndExit("Cluster deploy mode is not compatible with master \"local\"")
-      case (_, CLUSTER) if isShell(args.primaryResource) =>
-        printErrorAndExit("Cluster deploy mode is not applicable to Spark shells.")
+      case (MESOS, CLUSTER) if isShell(args.primaryResource) =>
+        printErrorAndExit("MESOS Cluster deploy mode is not compatible with Spark shells.")
+      case (YARN, CLUSTER) if isShell(args.primaryResource) =>
+        printErrorAndExit("YARN Cluster deploy mode is not compatible with Spark shells.")
+      case (STANDALONE, CLUSTER) if isShell(args.primaryResource) =>
+        printErrorAndExit("STANDALONE Cluster deploy mode is not compatible with Spark shells.")
       case (_, CLUSTER) if isSqlShell(args.mainClass) =>
         printErrorAndExit("Cluster deploy mode is not applicable to Spark SQL shell.")
       case (_, CLUSTER) if isThriftServer(args.mainClass) =>


### PR DESCRIPTION
Allows client and cluster mode for shell applications. Specifically, this was done to allow executing a Jupyter notebook server that is able to interact with the k8s cluster.

With this change, I was able to use `kubectl run` with an image that runs a Jupyter notebook with the `jupyter notebook` command. After port-forwarding to the container port that the server is running on, I can access and use the notebook as usual, and if I provide appropriate configuration values (`spark.master`, `spark.kubernetes.driver.docker.image`, etc.), Spark tasks interact as expected with the Kubernetes cluster, and dynamic allocation behaves as expected.

Along with Jupyter, I've tested and confirmed that the PySpark and Scala shells work, and with slight modifications, so does in-cluster spark-submit.

This PR is less intended for merging and more for figuring out how best to facilitate this in-cluster workflow with Jupyter and client-mode applications. I know that there have been previous discussions around this, such as [#211](https://github.com/apache-spark-on-k8s/spark/pull/211), and that there are limitations (executor IPs must be routable and other networking issues) but I would love to hear any thoughts around alternative approaches or solutions!