### PR TITLE
increase SparkReadinessWatcher wait time

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/SparkReadinessWatcher.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/SparkReadinessWatcher.scala
@@ -37,5 +37,5 @@ private[spark] class SparkReadinessWatcher[T <: HasMetadata] extends Watcher[T] 
 
   override def onClose(cause: KubernetesClientException): Unit = {}
 
-  def waitUntilReady(): Boolean = signal.get(30, TimeUnit.SECONDS)
+  def waitUntilReady(): Boolean = signal.get(60, TimeUnit.SECONDS)
 }


### PR DESCRIPTION
Test increase in readiness wait time to see if it stabilizes integration testing w/ RSS

so far: 5/6 integration tests passed