### PR TITLE
Exclude com.sun.jersey from docker-minimal-bundle.

### DIFF
--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/docker-assembly.xml
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/assembly/docker-assembly.xml
@@ -69,6 +69,7 @@
       <excludes>
         <exclude>org.apache.spark:spark-assembly_${scala.binary.version}:pom</exclude>
         <exclude>org.spark-project.spark:unused</exclude>
+        <exclude>com.sun.jersey:*</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
This probably is not the correct fix long-term as we should find the specific module that is pulling in the bad jersey-1 version. But until we can track down what the specific offending module is, this will have to do.
