### PR TITLE
Removed deprecated XX:MaxPermSize option from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2127,7 +2127,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraScalaTestArgs}</argLine>
+            <argLine>-ea -Xmx3g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraScalaTestArgs}</argLine>
             <stderr/>
             <environmentVariables>
               <!--


### PR DESCRIPTION
https://spark.apache.org/docs/latest/building-spark.html#apache-maven

```
Note that support for Java 7 was removed as of Spark 2.2.0.
```

The option `MaxPermSize` was removed in Java 8.