### PR TITLE
Added reference YAML files for RBAC configs for driver and shuffle service

### DIFF
--- a/conf/k8s-shuffle-service-rbac.yaml
+++ b/conf/k8s-shuffle-service-rbac.yaml
@@ -1,0 +1,80 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-shuffle-service-service-account
+  namespace: default
+  labels:
+    app: spark-shuffle-service
+    spark-version: 2.2.0
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: spark-shuffle-service-pod-security-policy
+  labels:
+    app: spark-shuffle-service
+    spark-version: 2.2.0
+spec:
+  privileged: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  volumes:
+  - "hostPath"
+  - "secret"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: spark-shuffle-service-role
+  labels:
+    app: spark-shuffle-service
+    spark-version: 2.2.0
+rules: 
+- apiGroups:
+  - "extensions"
+  resources:
+  - "podsecuritypolicies"
+  resourceNames:
+  - "spark-shuffle-service-pod-security-policy"
+  verbs:
+  - "use"
+- apiGroups:
+  - "" # "" indicates the core API group
+  resources:
+  - "pods"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+    name: spark-shuffle-service-role-binding
+subjects:
+- kind: ServiceAccount
+  name: spark-shuffle-service-service-account
+  namespace: default
+roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
+   name: spark-shuffle-service-role

--- a/conf/k8s-spark-rbac.yaml
+++ b/conf/k8s-spark-rbac.yaml
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: default
+  name: spark-role
+rules:
+- apiGroups:
+  - "" # "" indicates the core API group
+  resources:
+  - "pods"
+  verbs:
+  - "*"
+- apiGroups:
+  - "" # "" indicates the core API group
+  resources:
+  - "services"
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: spark-role-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: spark
+  namespace: default
+roleRef:
+  kind: Role
+  name: spark-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds YAML files for reference RBAC configuration for the Spark driver and shuffle service. To complement https://github.com/apache-spark-on-k8s/userdocs/pull/14.

Ref: #500.

## How was this patch tested?

Manual tests pending.

@foxish @kimoonkim 