### PR TITLE
Delete Kubernetes resources when the client waits for and sees app completion

### DIFF
--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -181,6 +181,17 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     verify(loggingPodStatusWatcher).awaitCompletion()
   }
 
+  test("Submission client should clean up Kubernetes resources upon application completion") {
+    val submissionClient = new Client(
+      submissionSteps,
+      new SparkConf(false),
+      kubernetesClient,
+      true,
+      "spark",
+      loggingPodStatusWatcher)
+    submissionClient.run()
+    verify(resourceList).delete()
+  }
 }
 
 private object FirstTestConfigurationStep extends DriverConfigurationStep {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes #519 for the case where the submission client waits for the submitted application to finish. Upon completion of the application, the submission client deletes all Kubernetes resources created for the application to run. 
