### PR TITLE
fix #538 - make /opt/spark/work-dir writable by gid 0 

### DIFF
--- a/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/spark-base/Dockerfile
+++ b/resource-managers/kubernetes/docker-minimal-bundle/src/main/docker/spark-base/Dockerfile
@@ -23,7 +23,8 @@ FROM openjdk:8-alpine
 RUN apk upgrade --no-cache && \
     apk add --no-cache bash tini && \
     mkdir -p /opt/spark && \
-    mkdir -p /opt/spark/work-dir \
+    mkdir -p /opt/spark/work-dir && \
+    chgrp -R root /opt/spark/work-dir && chmod -R ug+rwX /opt/spark/work-dir && \
     touch /opt/spark/RELEASE && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \


### PR DESCRIPTION
## What changes were proposed in this pull request?

make /opt/spark/work-dir writable by gid 0 to operate better in anonymous uid scenarios

(Please fill in changes proposed in this fix)

## How was this patch tested?

I'm using CI infra to fully test image creation and exercising via the unit/integration tests