### PR TITLE
Allow user-specified environment variables and secrets in the init-container

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkPodInitContainerBootstrap.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkPodInitContainerBootstrap.scala
@@ -18,7 +18,7 @@ package org.apache.spark.deploy.k8s
 
 import scala.collection.JavaConverters._
 
-import io.fabric8.kubernetes.api.model._
+import io.fabric8.kubernetes.api.model.{ContainerBuilder, EmptyDirVolumeSource, EnvVarBuilder, PodBuilder, VolumeMount, VolumeMountBuilder}
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.deploy.k8s.config._

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/config.scala
@@ -121,8 +121,6 @@ package object config extends Logging {
 
   private[spark] val KUBERNETES_DRIVER_ENV_KEY = "spark.kubernetes.driverEnv."
 
-  private[spark] val KUBERNETES_INITCONTAINER_ENV_KEY = "spark.kubernetes.initContainerEnv."
-
   private[spark] val KUBERNETES_DRIVER_SECRETS_PREFIX = "spark.kubernetes.driver.secrets."
   private[spark] val KUBERNETES_EXECUTOR_SECRETS_PREFIX = "spark.kubernetes.executor.secrets."
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/config.scala
@@ -121,6 +121,8 @@ package object config extends Logging {
 
   private[spark] val KUBERNETES_DRIVER_ENV_KEY = "spark.kubernetes.driverEnv."
 
+  private[spark] val KUBERNETES_INITCONTAINER_ENV_KEY = "spark.kubernetes.initContainerEnv."
+
   private[spark] val KUBERNETES_DRIVER_SECRETS_PREFIX = "spark.kubernetes.driver.secrets."
   private[spark] val KUBERNETES_EXECUTOR_SECRETS_PREFIX = "spark.kubernetes.executor.secrets."
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/initcontainer/InitContainerConfigurationStepsOrchestrator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/initcontainer/InitContainerConfigurationStepsOrchestrator.scala
@@ -99,6 +99,7 @@ private[spark] class InitContainerConfigurationStepsOrchestrator(
       downloadTimeoutMinutes,
       initContainerConfigMapName,
       initContainerConfigMapKey,
+      SPARK_POD_DRIVER_ROLE,
       submissionSparkConf)
     val baseInitContainerStep = new BaseInitContainerConfigurationStep(
       sparkJars,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/initcontainer/InitContainerMountSecretsStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/initcontainer/InitContainerMountSecretsStep.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.submit.submitsteps.initcontainer
+
+import org.apache.spark.deploy.k8s.submit.MountSecretsBootstrap
+
+/**
+ * An init-container configuration step for mounting user-specified secrets onto user-specified
+ * paths.
+ *
+ * @param mountSecretsBootstrap a utility actually handling mounting of the secrets.
+ */
+private[spark] class InitContainerMountSecretsStep(
+    mountSecretsBootstrap: MountSecretsBootstrap) extends InitContainerConfigurationStep {
+
+  override def configureInitContainer(initContainerSpec: InitContainerSpec) : InitContainerSpec = {
+    val (podWithSecretsMounted, initContainerWithSecretsMounted) =
+      mountSecretsBootstrap.mountSecrets(
+        initContainerSpec.podToInitialize,
+        initContainerSpec.initContainer)
+    initContainerSpec.copy(
+      podToInitialize = podWithSecretsMounted,
+      initContainer = initContainerWithSecretsMounted
+    )
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -79,6 +79,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         sparkConf.get(INIT_CONTAINER_MOUNT_TIMEOUT),
         configMap,
         configMapKey,
+        SPARK_POD_EXECUTOR_ROLE,
         sparkConf)
     }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.shuffle.kubernetes.KubernetesExternalShuffleClientImpl
 import org.apache.spark.scheduler.{ExternalClusterManager, SchedulerBackend, TaskScheduler, TaskSchedulerImpl}
-import org.apache.spark.util.{ThreadUtils, Utils}
+import org.apache.spark.util.ThreadUtils
 
 private[spark] class KubernetesClusterManager extends ExternalClusterManager with Logging {
 
@@ -78,7 +78,8 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         sparkConf.get(INIT_CONTAINER_FILES_DOWNLOAD_LOCATION),
         sparkConf.get(INIT_CONTAINER_MOUNT_TIMEOUT),
         configMap,
-        configMapKey)
+        configMapKey,
+        sparkConf)
     }
 
     val mountSmallFilesBootstrap = for {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -97,6 +97,11 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
     } else {
       None
     }
+    val executorInitContainerMountSecretsBootstrap = if (executorSecretNamesToMountPaths.nonEmpty) {
+      Some(new MountSecretsBootstrapImpl(executorSecretNamesToMountPaths))
+    } else {
+      None
+    }
 
     if (maybeInitContainerConfigMap.isEmpty) {
       logWarning("The executor's init-container config map was not specified. Executors will" +
@@ -135,6 +140,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         mountSecretBootstrap,
         mountSmallFilesBootstrap,
         executorInitContainerBootstrap,
+        executorInitContainerMountSecretsBootstrap,
         executorInitContainerSecretVolumePlugin,
         executorLocalDirVolumeProvider)
     val allocatorExecutor = ThreadUtils

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkPodInitContainerBootstrapSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SparkPodInitContainerBootstrapSuite.scala
@@ -16,14 +16,17 @@
  */
 package org.apache.spark.deploy.k8s
 
-import io.fabric8.kubernetes.api.model._
-import org.scalatest.BeforeAndAfter
 import scala.collection.JavaConverters._
 
+import io.fabric8.kubernetes.api.model._
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.k8s.config._
 import org.apache.spark.deploy.k8s.constants._
-import org.apache.spark.SparkFunSuite
 
 class SparkPodInitContainerBootstrapSuite extends SparkFunSuite with BeforeAndAfter {
+
   private val INIT_CONTAINER_IMAGE = "spark-init:latest"
   private val DOCKER_IMAGE_PULL_POLICY = "IfNotPresent"
   private val JARS_DOWNLOAD_PATH = "/var/data/spark-jars"
@@ -40,7 +43,8 @@ class SparkPodInitContainerBootstrapSuite extends SparkFunSuite with BeforeAndAf
     FILES_DOWNLOAD_PATH,
     DOWNLOAD_TIMEOUT_MINUTES,
     INIT_CONTAINER_CONFIG_MAP_NAME,
-    INIT_CONTAINER_CONFIG_MAP_KEY)
+    INIT_CONTAINER_CONFIG_MAP_KEY,
+    new SparkConf())
   private val expectedSharedVolumeMap = Map(
     JARS_DOWNLOAD_PATH -> INIT_CONTAINER_DOWNLOAD_JARS_VOLUME_NAME,
     FILES_DOWNLOAD_PATH -> INIT_CONTAINER_DOWNLOAD_FILES_VOLUME_NAME)
@@ -60,6 +64,7 @@ class SparkPodInitContainerBootstrapSuite extends SparkFunSuite with BeforeAndAf
     assert(initContainer.getImagePullPolicy === DOCKER_IMAGE_PULL_POLICY)
     assert(initContainer.getArgs.asScala.head === INIT_CONTAINER_PROPERTIES_FILE_PATH)
   }
+
   test("Main: Volume mounts and env") {
     val returnedPodWithCont = sparkPodInit.bootstrapInitContainerAndVolumes(
       PodWithDetachedInitContainer(
@@ -73,6 +78,7 @@ class SparkPodInitContainerBootstrapSuite extends SparkFunSuite with BeforeAndAf
     assert(mainContainer.getEnv.asScala.map(e => (e.getName, e.getValue)).toMap ===
       Map(ENV_MOUNTED_FILES_DIR -> FILES_DOWNLOAD_PATH))
   }
+
   test("Pod: Volume Mounts") {
     val returnedPodWithCont = sparkPodInit.bootstrapInitContainerAndVolumes(
       PodWithDetachedInitContainer(
@@ -91,6 +97,37 @@ class SparkPodInitContainerBootstrapSuite extends SparkFunSuite with BeforeAndAf
     assert(volumes(1).getEmptyDir === new EmptyDirVolumeSource())
     assert(volumes(2).getName === INIT_CONTAINER_DOWNLOAD_FILES_VOLUME_NAME)
     assert(volumes(2).getEmptyDir === new EmptyDirVolumeSource())
+  }
+
+  test("InitContainer: custom environment variables") {
+    val sparkConf = new SparkConf()
+      .set(s"${KUBERNETES_INITCONTAINER_ENV_KEY}env1", "val1")
+      .set(s"${KUBERNETES_INITCONTAINER_ENV_KEY}env2", "val2")
+    val initContainerBootstrap = new SparkPodInitContainerBootstrapImpl(
+      INIT_CONTAINER_IMAGE,
+      DOCKER_IMAGE_PULL_POLICY,
+      JARS_DOWNLOAD_PATH,
+      FILES_DOWNLOAD_PATH,
+      DOWNLOAD_TIMEOUT_MINUTES,
+      INIT_CONTAINER_CONFIG_MAP_NAME,
+      INIT_CONTAINER_CONFIG_MAP_KEY,
+      sparkConf)
+
+    val returnedPod = initContainerBootstrap.bootstrapInitContainerAndVolumes(
+      PodWithDetachedInitContainer(
+        pod = basePod().build(),
+        initContainer = new Container(),
+        mainContainer = new ContainerBuilder().withName(MAIN_CONTAINER_NAME).build()))
+    val initContainer: Container = returnedPod.initContainer
+
+    assert(initContainer.getEnv.size() == 2)
+    val envVars = initContainer
+      .getEnv
+      .asScala
+      .map(env => (env.getName, env.getValue))
+      .toMap
+    assert(envVars("env1") == "val1")
+    assert(envVars("env2") == "val2")
   }
 
   private def basePod(): PodBuilder = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/submitsteps/initcontainer/InitContainerMountSecretsStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/submitsteps/initcontainer/InitContainerMountSecretsStepSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.submit.submitsteps.initcontainer
+
+import io.fabric8.kubernetes.api.model.{ContainerBuilder, PodBuilder}
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.deploy.k8s.submit.{MountSecretsBootstrapImpl, SecretVolumeUtils}
+
+class InitContainerMountSecretsStepSuite extends SparkFunSuite {
+
+  private val SECRET_FOO = "foo"
+  private val SECRET_BAR = "bar"
+  private val SECRET_MOUNT_PATH = "/etc/secrets/init-container"
+
+  test("Mounts all given secrets") {
+    val baseInitContainerSpec = InitContainerSpec(
+      Map.empty,
+      Map.empty,
+      new ContainerBuilder().build(),
+      new ContainerBuilder().build(),
+      new PodBuilder().withNewMetadata().endMetadata().withNewSpec().endSpec().build(),
+      Seq.empty)
+    val secretNamesToMountPaths = Map(
+      SECRET_FOO -> SECRET_MOUNT_PATH,
+      SECRET_BAR -> SECRET_MOUNT_PATH)
+
+    val mountSecretsBootstrap = new MountSecretsBootstrapImpl(secretNamesToMountPaths)
+    val initContainerMountSecretsStep = new InitContainerMountSecretsStep(mountSecretsBootstrap)
+    val configuredInitContainerSpec = initContainerMountSecretsStep.configureInitContainer(
+      baseInitContainerSpec)
+
+    val podWithSecretsMounted = configuredInitContainerSpec.podToInitialize
+    val initContainerWithSecretsMounted = configuredInitContainerSpec.initContainer
+
+    Seq(s"$SECRET_FOO-volume", s"$SECRET_BAR-volume").foreach(volumeName =>
+      assert(SecretVolumeUtils.podHasVolume(podWithSecretsMounted, volumeName)))
+    Seq(s"$SECRET_FOO-volume", s"$SECRET_BAR-volume").foreach(volumeName =>
+      assert(SecretVolumeUtils.containerHasVolume(
+        initContainerWithSecretsMounted, volumeName, SECRET_MOUNT_PATH)))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR allows setting user-specified environment variables and mounting user-specified secrets in the init-container. The driver init-container gets user-specified environment variables and secrets for the driver, whereas the executor init-container gets those for the executors. This is for #562 to enable the init-container to be able to download remote dependencies from Hadoop-compatible sources, e.g., HDFS, GCS, and S3. 

## How was this patch tested?

Unit tests.

@mccheah @foxish @kimoonkim 