### PR TITLE
add spark.kubernetes.hadoop.conf.configmap.name conf to use exist had…

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -838,6 +838,15 @@ from the other deployment modes. See the [configuration page](configuration.html
     in the executor Pods. The user can specify multiple instances of this for multiple secrets.
   </td>
 </tr>
+<tr>
+  <td><code>spark.kubernetes.hadoop.conf.configmap.name</code></td>
+  <td>(none)</td>
+  <td>
+    If this is specified, will not create new configmap to store hadoop conf file and reuse the
+    exist configmap. The configmap will be mounted into driver/executor pod and
+    <code>HADOOP_CONF_DIR</code> will be set.
+  </td>
+</tr>
 </table>
 
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/HadoopConfBootstrap.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/HadoopConfBootstrap.scala
@@ -39,25 +39,18 @@ private[spark] trait HadoopConfBootstrap {
 }
 
 private[spark] class HadoopConfBootstrapImpl(
-  hadoopConfConfigMapName: String,
-  hadoopConfigFiles: Seq[File]) extends HadoopConfBootstrap with Logging {
+  hadoopConfConfigMapName: String) extends HadoopConfBootstrap with Logging {
 
   override def bootstrapMainContainerAndVolumes(originalPodWithMainContainer: PodWithMainContainer)
     : PodWithMainContainer = {
-    logInfo("HADOOP_CONF_DIR defined. Mounting Hadoop specific files")
-    val keyPaths = hadoopConfigFiles.map { file =>
-      val fileStringPath = file.toPath.getFileName.toString
-      new KeyToPathBuilder()
-        .withKey(fileStringPath)
-        .withPath(fileStringPath)
-      .build() }
+    logInfo("HADOOP_CONF_DIR or spark.kubernetes.hadoop.conf.configmap.name defined. " +
+      "Mounting Hadoop specific files")
     val hadoopSupportedPod = new PodBuilder(originalPodWithMainContainer.pod)
       .editSpec()
         .addNewVolume()
           .withName(HADOOP_FILE_VOLUME)
           .withNewConfigMap()
             .withName(hadoopConfConfigMapName)
-            .withItems(keyPaths.asJava)
             .endConfigMap()
           .endVolume()
         .endSpec()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/config.scala
@@ -539,6 +539,13 @@ package object config extends Logging {
       .stringConf
       .createOptional
 
+  private[spark] val KUBERNETES_HADOOP_CONF_CONFIGMAP_NAME =
+    ConfigBuilder("spark.kubernetes.hadoop.conf.configmap.name")
+      .doc("Specify the configmap name of the config where the hadoop conf exist." +
+        "It will be mounted to spark pods.")
+      .stringConf
+      .createOptional
+
   private[spark] def resolveK8sMaster(rawMasterString: String): String = {
     if (!rawMasterString.startsWith("k8s://")) {
       throw new IllegalArgumentException("Master URL should start with k8s:// in Kubernetes mode.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -88,11 +88,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
     }
 
     val hadoopBootStrap = maybeHadoopConfigMap.map{ hadoopConfigMap =>
-      val hadoopConfigurations = maybeHadoopConfDir.map(
-          conf_dir => HadoopConfUtils.getHadoopConfFiles(conf_dir)).getOrElse(Seq.empty[File])
-      new HadoopConfBootstrapImpl(
-        hadoopConfigMap,
-        hadoopConfigurations)
+      new HadoopConfBootstrapImpl(hadoopConfigMap)
     }
 
     val kerberosBootstrap =

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/HadoopConfBootstrapSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/HadoopConfBootstrapSuite.scala
@@ -34,7 +34,6 @@ import org.apache.spark.util.Utils
 private[spark] class HadoopConfBootstrapSuite extends SparkFunSuite with BeforeAndAfter{
   private val CONFIG_MAP_NAME = "config-map"
   private val TEMP_HADOOP_FILE = createTempFile("core-site.xml")
-  private val HADOOP_FILES = Seq(TEMP_HADOOP_FILE)
   private val SPARK_USER_VALUE = "sparkUser"
 
   before {
@@ -42,21 +41,13 @@ private[spark] class HadoopConfBootstrapSuite extends SparkFunSuite with BeforeA
   }
 
   test("Test of bootstrapping hadoop_conf_dir files") {
-    val hadoopConfStep = new HadoopConfBootstrapImpl(
-      CONFIG_MAP_NAME,
-      HADOOP_FILES)
-    val expectedKeyPaths = Seq(
-      new KeyToPathBuilder()
-        .withKey(TEMP_HADOOP_FILE.toPath.getFileName.toString)
-        .withPath(TEMP_HADOOP_FILE.toPath.getFileName.toString)
-        .build())
+    val hadoopConfStep = new HadoopConfBootstrapImpl(CONFIG_MAP_NAME)
     val expectedPod = new PodBuilder()
       .editOrNewSpec()
           .addNewVolume()
             .withName(HADOOP_FILE_VOLUME)
             .withNewConfigMap()
               .withName(CONFIG_MAP_NAME)
-              .withItems(expectedKeyPaths.asJava)
               .endConfigMap()
             .endVolume()
           .endSpec()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/submitsteps/hadoopsteps/HadoopConfMounterStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/submitsteps/hadoopsteps/HadoopConfMounterStepSuite.scala
@@ -73,7 +73,7 @@ private[spark] class HadoopConfMounterStepSuite extends SparkFunSuite with Befor
       CONFIG_MAP_NAME,
       HADOOP_FILES,
       hadoopConfBootstrap,
-      HADOOP_CONF_DIR_VAL)
+      Some(HADOOP_CONF_DIR_VAL))
     val expectedDriverSparkConf = Map(HADOOP_CONF_DIR_LOC -> HADOOP_CONF_DIR_VAL)
     val expectedConfigMap = Map(
       TEMP_HADOOP_FILE.toPath.getFileName.toString ->

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/submitsteps/hadoopsteps/HadoopStepsOrchestratorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/submitsteps/hadoopsteps/HadoopStepsOrchestratorSuite.scala
@@ -33,7 +33,7 @@ private[spark] class HadoopStepsOrchestratorSuite extends SparkFunSuite {
       NAMESPACE,
       HADOOP_CONFIG_MAP,
       sparkTestConf,
-      HADOOP_CONF_DIR_VAL)
+      Some(HADOOP_CONF_DIR_VAL))
     val steps = hadoopOrchestrator.getHadoopSteps()
     assert(steps.length === 2)
     assert(steps.head.isInstanceOf[HadoopConfMounterStep])
@@ -50,7 +50,7 @@ private[spark] class HadoopStepsOrchestratorSuite extends SparkFunSuite {
       NAMESPACE,
       HADOOP_CONFIG_MAP,
       sparkTestConf,
-      HADOOP_CONF_DIR_VAL)
+      Some(HADOOP_CONF_DIR_VAL))
     val steps = hadoopOrchestrator.getHadoopSteps()
     assert(steps.length === 2)
     assert(steps.head.isInstanceOf[HadoopConfMounterStep])
@@ -65,7 +65,7 @@ private[spark] class HadoopStepsOrchestratorSuite extends SparkFunSuite {
       NAMESPACE,
       HADOOP_CONFIG_MAP,
       sparkTestConf,
-      HADOOP_CONF_DIR_VAL)
+      Some(HADOOP_CONF_DIR_VAL))
     val steps = hadoopOrchestrator.getHadoopSteps()
     assert(steps.length === 2)
     assert(steps.head.isInstanceOf[HadoopConfMounterStep])
@@ -82,7 +82,7 @@ private[spark] class HadoopStepsOrchestratorSuite extends SparkFunSuite {
       NAMESPACE,
       HADOOP_CONFIG_MAP,
       sparkTestConf,
-      HADOOP_CONF_DIR_VAL)
+      Some(HADOOP_CONF_DIR_VAL))
     val steps = hadoopOrchestrator.getHadoopSteps()
     assert(steps.length === 2)
     assert(steps.head.isInstanceOf[HadoopConfMounterStep])

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodFactorySuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodFactorySuite.scala
@@ -349,11 +349,7 @@ class ExecutorPodFactorySuite extends SparkFunSuite with BeforeAndAfter with Bef
     when(hadoopUGI.getShortUserName).thenReturn("test-user")
     val conf = baseConf.clone()
     val configName = "hadoop-test"
-    val hadoopFile = createTempFile
-    val hadoopFiles = Seq(hadoopFile)
-    val hadoopBootsrap = new HadoopConfBootstrapImpl(
-      hadoopConfConfigMapName = configName,
-      hadoopConfigFiles = hadoopFiles)
+    val hadoopBootsrap = new HadoopConfBootstrapImpl(configName)
 
     val factory = new ExecutorPodFactoryImpl(
       conf,
@@ -376,8 +372,7 @@ class ExecutorPodFactorySuite extends SparkFunSuite with BeforeAndAfter with Bef
     checkOwnerReferences(executor, driverPodUid)
     checkConfigMapVolumes(executor,
       HADOOP_FILE_VOLUME,
-      configName,
-      hadoopFile.toPath.getFileName.toString)
+      configName)
     checkVolumeMounts(executor, HADOOP_FILE_VOLUME, HADOOP_CONF_DIR_PATH)
   }
 
@@ -385,11 +380,7 @@ class ExecutorPodFactorySuite extends SparkFunSuite with BeforeAndAfter with Bef
     when(hadoopUGI.getShortUserName).thenReturn("test-user")
     val conf = baseConf.clone()
     val configName = "hadoop-test"
-    val hadoopFile = createTempFile
-    val hadoopFiles = Seq(hadoopFile)
-    val hadoopBootstrap = new HadoopConfBootstrapImpl(
-      hadoopConfConfigMapName = configName,
-      hadoopConfigFiles = hadoopFiles)
+    val hadoopBootstrap = new HadoopConfBootstrapImpl(configName)
     val hadoopUserBootstrap = new HadoopConfSparkUserBootstrapImpl(hadoopUGI)
 
     val factory = new ExecutorPodFactoryImpl(
@@ -414,8 +405,7 @@ class ExecutorPodFactorySuite extends SparkFunSuite with BeforeAndAfter with Bef
     checkOwnerReferences(executor, driverPodUid)
     checkConfigMapVolumes(executor,
       HADOOP_FILE_VOLUME,
-      configName,
-      hadoopFile.toPath.getFileName.toString)
+      configName)
     checkVolumeMounts(executor, HADOOP_FILE_VOLUME, HADOOP_CONF_DIR_PATH)
   }
 
@@ -423,11 +413,7 @@ class ExecutorPodFactorySuite extends SparkFunSuite with BeforeAndAfter with Bef
     when(hadoopUGI.getShortUserName).thenReturn("test-user")
     val conf = baseConf.clone()
     val configName = "hadoop-test"
-    val hadoopFile = createTempFile
-    val hadoopFiles = Seq(hadoopFile)
-    val hadoopBootstrap = new HadoopConfBootstrapImpl(
-      hadoopConfConfigMapName = configName,
-      hadoopConfigFiles = hadoopFiles)
+    val hadoopBootstrap = new HadoopConfBootstrapImpl(configName)
     val secretName = "secret-test"
     val secretItemKey = "item-test"
     val userName = "sparkUser"
@@ -459,8 +445,7 @@ class ExecutorPodFactorySuite extends SparkFunSuite with BeforeAndAfter with Bef
     checkOwnerReferences(executor, driverPodUid)
     checkConfigMapVolumes(executor,
       HADOOP_FILE_VOLUME,
-      configName,
-      hadoopFile.toPath.getFileName.toString)
+      configName)
     checkSecretVolumes(executor, SPARK_APP_HADOOP_SECRET_VOLUME_NAME, secretName)
     checkVolumeMounts(executor, HADOOP_FILE_VOLUME, HADOOP_CONF_DIR_PATH)
     checkVolumeMounts(executor,
@@ -505,15 +490,10 @@ class ExecutorPodFactorySuite extends SparkFunSuite with BeforeAndAfter with Bef
 
   private def checkConfigMapVolumes(executor: Pod,
     volName: String,
-    configMapName: String,
-    content: String) : Unit = {
+    configMapName: String) : Unit = {
     val volume = executor.getSpec.getVolumes.asScala.find(_.getName == volName)
     assert(volume.nonEmpty)
     assert(volume.get.getConfigMap.getName == configMapName)
-    assert(volume.get.getConfigMap.getItems.asScala.find(_.getKey == content).get ==
-      new KeyToPathBuilder()
-        .withKey(content)
-        .withPath(content).build() )
   }
 
   private def checkSecretVolumes(executor: Pod, volName: String, secretName: String) : Unit = {


### PR DESCRIPTION
…oop conf configmap

Signed-off-by: forrestchen <forrestchen@tencent.com>

## What changes were proposed in this pull request?

see issue #580 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
manual tests

I manually run the pagerank example by following script

```
export HADOOP_CONF_DIR=`pwd`/littlehadoopconf
export SPARK_EXECUTOR_MEMORY=2G

bin/spark-submit \
  --deploy-mode cluster \
  --class org.apache.spark.examples.SparkPageRank \
  --master k8s://http://10.0.0.1:8080 \
  --kubernetes-namespace default \
  --conf spark.app.name=forrestperf-pagerank \
  --conf spark.kubernetes.driver.docker.image=spark-driver:cm0108 \
  --conf spark.kubernetes.executor.docker.image=spark-executor:cm0108 \
  --conf spark.kubernetes.initcontainer.docker.image=spark-init:cm0108 \
  --conf spark.kubernetes.resourceStagingServer.uri=http://10.0.0.2:31000 \
  --conf spark.eventLog.enabled=true \
  --conf spark.eventLog.dir=hdfs://hdfsCluster/spark/ramieventlog \
  --conf spark.kubernetes.delete.executors=false \
  --conf spark.kubernetes.initcontainer.inannotation=true \
  --conf spark.dynamicAllocation.enabled=true \
  --conf spark.shuffle.service.enabled=true \
  --conf spark.kubernetes.shuffle.namespace=default \
  --conf spark.kubernetes.shuffle.labels="app=spark-shuffle-service,spark-version=2.2.0" \
  --conf spark.kubernetes.hadoop.conf.configmap.name="little-hadoop-config" \
  --conf spark.local.dir=/data/spark-local \
  --conf spark.kubernetes.node.selector.subnet=10.175.106.192-26 \
  --conf spark.kubernetes.docker.image.pullPolicy=Always \
  examples/jars/spark-examples_2.11-2.2.0-k8s-0.5.0.jar \
  hdfs://hdfsCluster/spark/data/pagerank/data/part-00001 10
```

with the conf `spark.kubernetes.hadoop.conf.configmap.name`, we can re-use the existing hadoop-conf-file instead create a new one indicate by `export HADOOP_CONF_DIR=xxx`


