### PR TITLE
Add message to redirect PRs upstream if possible

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -4,8 +4,12 @@ We are attempting to re-direct as much new development as possible to the upstre
 Please consider whether your pull request can be submitted against the Apache Spark project, and submit there if possible.
 
 If you have any questions about whether a PR should be submitted upstream or against this fork,
-please feel free to ask on the Big Data SIG [slack channel](https://kubernetes.slack.com/),
-or at the regular Big Data SIG [meetings](https://github.com/kubernetes/community/tree/master/sig-big-data).
+please feel free to reach out on the following channels:
+
+* Apache Spark developer mailing list: dev@spark.apache.org
+* Apache Spark [JIRA](https://issues.apache.org/jira/)
+* Big Data SIG [slack channel](https://kubernetes.slack.com/)
+* Regular Big Data SIG [meetings](https://github.com/kubernetes/community/tree/master/sig-big-data)
 
 ## What changes were proposed in this pull request?
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,3 +1,12 @@
+## Before you submit a Pull Request
+The Kubernetes scheduler backend is currently being upstreamed to the main [Apache Spark project](https://github.com/apache/spark).
+We are attempting to re-direct as much new development as possible to the upstream.
+Please consider whether your pull request can be submitted against the Apache Spark project, and submit there if possible.
+
+If you have any questions about whether a PR should be submitted upstream or against this fork,
+please feel free to ask on the Big Data SIG [slack channel](https://kubernetes.slack.com/),
+or at the regular Big Data SIG [meetings](https://github.com/kubernetes/community/tree/master/sig-big-data).
+
 ## What changes were proposed in this pull request?
 
 (Please fill in changes proposed in this fix)


### PR DESCRIPTION
We want to re-direct community dev upstream as much as possible. However, some contributions impact components (e.g. shuffle server) that do not yet exist upstream. To handle this, we decided to add this message and leave it up to developers, but encourage them to submit upstream unless it isn't feasible.
