### PR TITLE
remove camel case naming in kerberos secret names

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/constants.scala
@@ -110,11 +110,11 @@ package object constants {
 
   // Kerberos Configuration
   private[spark] val KERBEROS_DELEGEGATION_TOKEN_SECRET_NAME =
-    "spark.kubernetes.kerberos.delegationTokenSecretName"
+    "spark.kubernetes.kerberos.delegation-token-secret-name"
   private[spark] val KERBEROS_KEYTAB_SECRET_NAME =
-    "spark.kubernetes.kerberos.keyTabSecretName"
+    "spark.kubernetes.kerberos.key-tab-secret-name"
   private[spark] val KERBEROS_KEYTAB_SECRET_KEY =
-    "spark.kubernetes.kerberos.keyTabSecretKey"
+    "spark.kubernetes.kerberos.key-tab-secret-key"
   private[spark] val KERBEROS_SECRET_LABEL_PREFIX =
     "hadoop-tokens"
   private[spark] val SPARK_HADOOP_PREFIX = "spark.hadoop."


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a bugfix for PR #540 (Basic Secure HDFS Support).

The `HadoopKerberosKeytabResolverStep` currently uses the constant
`KERBEROS_DELEGEGATION_TOKEN_SECRET_NAME` when storing the Kerberos
delegation token into a Kubernetes secret - this however causes a 
`KubernetesClientException` stating the following as secret names are supposed to adhere to RFC 1123:

```
a DNS-1123 subdomain must consist of lower case alphanumeric characters,
'-' or '.', and must start and end with an alphanumeric character (e.g.
'example.com', regex used for validation is
'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

The code in question is https://github.com/apache-spark-on-k8s/spark/blob/branch-2.2-kubernetes/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/hadoopsteps/HadoopKerberosKeytabResolverStep.scala#L102

The problem is that the current constants are using camel case, so I have changed the values to not use any uppercase characters anymore.


## How was this patch tested?

This was tested manually (against a Kubernetes cluster with version v1.8.5), since the currently implemented unit tests only use mocks and the above Exception is only thrown when the actual Kubernetes API is called.
