### PR TITLE
Fix invalid secret name, fixes #620

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/hadoopsteps/HadoopKerberosKeytabResolverStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/hadoopsteps/HadoopKerberosKeytabResolverStep.scala
@@ -100,6 +100,7 @@ private[spark] class HadoopKerberosKeytabResolverStep(
       val initialTokenDataKeyName = s"$KERBEROS_SECRET_LABEL_PREFIX-$currentTime-$renewalInterval"
       val uniqueSecretName =
         s"$kubernetesResourceNamePrefix-$KERBEROS_DELEGEGATION_TOKEN_SECRET_NAME.$currentTime"
+        .toLowerCase
       val secretDT =
         new SecretBuilder()
           .withNewMetadata()


### PR DESCRIPTION
As reported in #620 invalid secret names are being generated by Spark on K8S.  This commit adds a`toLowerCase` to the generated name to pass the validation regex.  The specific problem is that the current name generation creates a segment containing  K8S requires that each segment start with an alphabetic character.

## How was this patch tested?

Tested against a secure HDFS cluster to verify successful mounting of the Hadoop Kerberos secret volume
