### PR TITLE
Fix hard code cluster name

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -3,3 +3,4 @@ docs/_build/
 pyspark.egg-info
 build/
 dist/
+.eggs/

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/DriverServiceBootstrapStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/submitsteps/DriverServiceBootstrapStep.scala
@@ -80,7 +80,7 @@ private[spark] class DriverServiceBootstrapStep(
       .build()
 
     val namespace = submissionSparkConf.get(KUBERNETES_NAMESPACE)
-    val driverHostname = s"${driverService.getMetadata.getName}.$namespace.svc.cluster.local"
+    val driverHostname = s"${driverService.getMetadata.getName}.$namespace.svc"
     val resolvedSparkConf = driverSpec.driverSparkConf.clone()
         .set(org.apache.spark.internal.config.DRIVER_HOST_ADDRESS, driverHostname)
         .set("spark.driver.port", driverPort.toString)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/submitsteps/DriverServiceBootstrapStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/submitsteps/DriverServiceBootstrapStepSuite.scala
@@ -84,7 +84,7 @@ private[spark] class DriverServiceBootstrapStepSuite
     val resolvedDriverSpec = configurationStep.configureDriver(baseDriverSpec)
     val expectedServiceName = SHORT_RESOURCE_NAME_PREFIX +
       DriverServiceBootstrapStep.DRIVER_SVC_POSTFIX
-    val expectedHostName = s"$expectedServiceName.my-namespace.svc.cluster.local"
+    val expectedHostName = s"$expectedServiceName.my-namespace.svc"
     verifySparkConfHostNames(resolvedDriverSpec.driverSparkConf, expectedHostName)
   }
 
@@ -119,7 +119,7 @@ private[spark] class DriverServiceBootstrapStepSuite
     val driverService = resolvedDriverSpec.otherKubernetesResources.head.asInstanceOf[Service]
     val expectedServiceName = s"spark-10000${DriverServiceBootstrapStep.DRIVER_SVC_POSTFIX}"
     assert(driverService.getMetadata.getName === expectedServiceName)
-    val expectedHostName = s"$expectedServiceName.my-namespace.svc.cluster.local"
+    val expectedHostName = s"$expectedServiceName.my-namespace.svc"
     verifySparkConfHostNames(resolvedDriverSpec.driverSparkConf, expectedHostName)
   }
 


### PR DESCRIPTION
## Before you submit a Pull Request
The Kubernetes scheduler backend is currently being upstreamed to the main [Apache Spark project](https://github.com/apache/spark).
We are attempting to re-direct as much new development as possible to the upstream.
Please consider whether your pull request can be submitted against the Apache Spark project, and submit there if possible.

If you have any questions about whether a PR should be submitted upstream or against this fork,
please feel free to reach out on the following channels:

* Apache Spark developer mailing list: dev@spark.apache.org
* Apache Spark [JIRA](https://issues.apache.org/jira/)
* Big Data SIG [slack channel](https://kubernetes.slack.com/)
* Regular Big Data SIG [meetings](https://github.com/kubernetes/community/tree/master/sig-big-data)

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
